### PR TITLE
another minor cleanup

### DIFF
--- a/src/checkit.py
+++ b/src/checkit.py
@@ -41,8 +41,8 @@ Traceback (most recent call last):
 ValueError: One is bigger than zero
 
 Of course, it's not only the brevity that we aim for, but the readability
-of code. Of course, as usually, whether this approach is more readdable or not
-is subjenctive, but you will see many examples that in our opinion do make
+of code. Of course, as usually, whether this approach is more readable or not
+is subjective, but you will see many examples that in our opinion do make
  the checkit approach more readable than the corresponding if-blocks.
 
 If you are fine with AssertionError (actually, the only exception class
@@ -73,9 +73,9 @@ as not having length:
 >>> check_length(True, 1, assign_length_to_others=True)
 
 Note that above we used the parameter `operator`. You can use it in several
-functions, and it can take nine operators from the operator module (use
+functions, and it can take eight operators from the operator module (use
 `get_possible_operators()` too see their list, which is eq, le, lt, gt, ge, ne,
-is_, is_not). These operators are actually functions, so you simple provide
+is_, is_not). These operators are actually functions, so you simply provide
 them as function names, as we did above.
 
 Now we want to check the instance of the following string:
@@ -151,11 +151,8 @@ must follow all of the following conditions:
 """
 
 import os
-import sys
-
-from operator import eq, le, lt, gt, ge, ne, is_, is_not
 from collections.abc import Generator
-from itertools import zip_longest
+from operator import eq, le, lt, gt, ge, ne, is_, is_not
 from pathlib import Path
 
 
@@ -195,7 +192,7 @@ def check_if(condition, error=AssertionError, message=None):
 
     If yes, returns nothing. If not, throws an error with an optional message.
     This is a generic function, used by other functions of the module.
-    
+
     It works as follows:
     >>> check_if(2 > 1)
     >>> check_if(2 < 1)
@@ -438,8 +435,8 @@ def check_if_paths_exist(paths,
 
 def _return_from_check_if_paths_exist(error, message, paths):
     """Create a tuple to return from check_if_paths_exist, message-dependent.
-    
-    
+
+
     >>> _return_from_check_if_paths_exist(
     ...    error=FileNotFoundError,
     ...    message=None,
@@ -1002,7 +999,7 @@ def _check_checkit_arguments(error=None,
         if not isinstance(assign_length_to_others, bool):
             raise TypeError('assign_length_to_others should be a bool')
     if execution_mode is not None:
-        if not execution_mode in ('raise', 'return'):
+        if execution_mode not in ('raise', 'return'):
             raise ValueError(
                 'execution_mode should be either "raise" or "return"')
     if expected_instance is not None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,8 +1,7 @@
 import os
 import pytest
-import sys
-import checkit
-
+from collections.abc import Generator
+from operator import eq, le, lt, gt, ge, ne, is_, is_not
 from checkit import (check_if, assert_if,
                      check_if_not, assert_if_not,
                      check_instance, assert_instance,
@@ -26,34 +25,28 @@ from checkit import (check_if, assert_if,
                      _make_message,
                      )
 
-from collections.abc import Generator
-
-from operator import eq, le, lt, gt, ge, ne, is_, is_not
-
 
 def test_check_if_edge_cases():
-    assert check_if(True) is None
     with pytest.raises(TypeError,
                        match="missing 1 required positional argument"):
         check_if()
     with pytest.raises(ValueError, match='The condition does not give'):
         check_if('tomato soup is good')
     with pytest.raises(ValueError, match='The condition does not give'):
-        check_if(22)
+        check_if('')
     with pytest.raises(ValueError, match='The condition does not give'):
         check_if(1)
     with pytest.raises(ValueError, match='The condition does not give'):
         check_if(0)
+    assert check_if(True) is None
     with pytest.raises(AssertionError):
         check_if(False)
     with pytest.raises(TypeError, match='error must be an exception'):
         check_if(1, 1)
-    with pytest.raises(TypeError, match='error must be an exception'):
-        check_if(1, 1, 1)
+    with pytest.raises(TypeError, match='message must be either None or string'):
+        check_if(1, ValueError, 1)
     with pytest.raises(TypeError, match='takes from 1 to 3 positional'):
         check_if(1, 1, 1, 1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        check_if(Condition=12 > 5)
 
 
 def test_check_if_positive():
@@ -67,10 +60,8 @@ def test_check_if_negative():
         check_if(2 < 1)
     with pytest.raises(ValueError):
         check_if(2 < 1, error=ValueError)
-    with pytest.raises(ValueError):
-        check_if(2 < 1, error=ValueError)
-    with pytest.raises(TypeError):
-        check_if('a' > 2)
+    with pytest.raises(ValueError, match='incorrect value'):
+        check_if(2 < 1, error=ValueError, message='incorrect value')
 
 
 def test_check_if_not_edge_cases():
@@ -80,7 +71,7 @@ def test_check_if_not_edge_cases():
     with pytest.raises(ValueError, match='The condition does not give'):
         check_if_not('tomato soup is good')
     with pytest.raises(ValueError, match='The condition does not give'):
-        check_if_not(22)
+        check_if_not('')
     with pytest.raises(ValueError, match='The condition does not give'):
         check_if_not(1)
     with pytest.raises(ValueError, match='The condition does not give'):
@@ -90,12 +81,10 @@ def test_check_if_not_edge_cases():
         check_if_not(True)
     with pytest.raises(TypeError, match='error must be an exception'):
         check_if_not(1, 1)
-    with pytest.raises(TypeError, match='error must be an exception'):
-        check_if_not(1, 1, 1)
+    with pytest.raises(TypeError, match='message must be either None or string'):
+        check_if_not(1, ValueError, 1)
     with pytest.raises(TypeError, match='takes from 1 to 3 positional'):
         check_if_not(1, 1, 1, 1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        check_if_not(Condition=12 > 5)
 
 
 def test_check_if_not_positive():
@@ -108,10 +97,8 @@ def test_check_if_not_negative():
         check_if_not(2 > 1)
     with pytest.raises(ValueError):
         check_if_not(2 > 1, error=ValueError)
-    with pytest.raises(ValueError):
-        check_if_not(2 > 1, error=ValueError)
-    with pytest.raises(TypeError):
-        check_if_not('a' > 2)
+    with pytest.raises(ValueError, match='incorrect value'):
+        check_if_not(2 > 1, error=ValueError, message='incorrect value')
 
 
 def test_check_length_edge_cases():
@@ -125,10 +112,6 @@ def test_check_length_edge_cases():
         check_length(1, 1, 1)
     with pytest.raises(TypeError, match='BaseException type, not str'):
         pytest.raises('tomato soup', 'is good')
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        check_length(Item=2)
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        check_length(item=2, length=5)
 
 
 def test_check_length_positive():
@@ -136,6 +119,7 @@ def test_check_length_positive():
     assert check_length('string', 6) is None
     assert check_length([1, 2], 2) is None
     assert check_length(range(0, 3), 3) is None
+    assert check_length(10, 1, assign_length_to_others=True) is None
 
 
 def test_check_length_negative():
@@ -145,7 +129,6 @@ def test_check_length_negative():
         check_length(None)
     with pytest.raises(TypeError, match="object of type 'int' has"):
         check_length(10, 1)
-    assert check_length(10, 1, assign_length_to_others=True) is None
 
 
 def test_check_instance_edge_cases():


### PR DESCRIPTION
I've made a few changes:

- fixed some typos
- removed unused imports
- ordered imports to make them more in line with PEP8
- deleted tests checking for `unexpected keyword argument`. I think they don't tell us anything about whether the function's arguments are named as we expect them to be. Also, you can't test for all possible misspellings of named arguments.
- deleted duplicate tests and replaced a couple of others with more meaningful versions (I hope).

This cleanup work is far from done yet - it only covers functions up to and including `check_length`.