### PR TITLE
Add docs with try

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Here is a list of :code:`easycheck` functions the module offers, along with thei
 * :code:`check_all_ifs()` (used to check multiple conditions and return all the checks)
 * :code:`check_argument()` (used to make several checks of a function's argument)
 
-You can also use a :code:`catch_check()` function, if you want to catch an exception or a warning the :code:`easycheck` function you use would raise.
+You can also use a :code:`catch_check()` function, if you want to catch an exception or a warning the :code:`easycheck` function you use would raise (see examples `here <https://github.com/nyggus/easycheck/blob/master/docs/catch_exceptions_doctest.rst>`_). Sometimes, however, you will do better using a :code:`try-except` block to catch exceptions (`see examples <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_).
 
 Use in code to issue warnings
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Install and update using pip:
 Testing
 -------
 
-The package is covered with both pytests and doctests. The latter are included in both docstrings of all the functions, but also in `documentation files <https://github.com/nyggus/easycheck/blob/master/docs>`_.
+The package is covered with both pytests and doctests. The latter are included in both docstrings of all the functions, but also in `documentation files <https://github.com/nyggus/easycheck/tree/master/docs>`_.
 
 Use in code to raise exceptions
 -------------------------------

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,4 +8,5 @@ This directory contains more detailed documentation of the :code:`easycheck` mod
 * `how to use in testing <https://github.com/nyggus/easycheck/blob/master/docs/use_in_testing_doctest.rst>`_;
 * `how to issue warnings <https://github.com/nyggus/easycheck/blob/master/docs/use_with_warnings_doctest.rst>`_;
 * `how to catch exceptions instead of raise them <https://github.com/nyggus/easycheck/blob/master/docs/catch_exceptions_doctest.rst>`_;
-* `more detailed examples with self-defined functions <https://github.com/nyggus/easycheck/blob/master/docs/use_for_self_defined_functions_doctest.rst>`_.
+* `more detailed examples with self-defined functions <https://github.com/nyggus/easycheck/blob/master/docs/use_for_self_defined_functions_doctest.rst>`_;
+* `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_.

--- a/docs/catch_exceptions_doctest.rst
+++ b/docs/catch_exceptions_doctest.rst
@@ -20,4 +20,4 @@ If you do not want to raise exceptions but to catch them instead, you can do so 
         ...
     ValueError: Incorrect value
 
-Nonetheless, in many situations, you will do better using a simpler and more readbale approach, that is, catching exceptions using the :code:`try-except` block. This approach is particularly readable and efficient when you want to check several things. See  `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_).
+Nonetheless, in many situations, you will do better using a simpler and more readbale approach, that is, catching exceptions using the :code:`try-except` block. This approach is particularly readable and efficient when you want to check several things. See  `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_.

--- a/docs/catch_exceptions_doctest.rst
+++ b/docs/catch_exceptions_doctest.rst
@@ -19,3 +19,5 @@ If you do not want to raise exceptions but to catch them instead, you can do so 
     Traceback (most recent call last):
         ...
     ValueError: Incorrect value
+
+Nonetheless, in many situations, you will do better using a simpler and more readbale approach, that is, catching exceptions using the :code:`try-except` block. This approach is particularly readable and efficient when you want to check several things. See  `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_).

--- a/docs/catch_exceptions_doctest.rst
+++ b/docs/catch_exceptions_doctest.rst
@@ -20,4 +20,4 @@ If you do not want to raise exceptions but to catch them instead, you can do so 
         ...
     ValueError: Incorrect value
 
-Nonetheless, in many situations, you will do better using a simpler and more readbale approach, that is, catching exceptions using the :code:`try-except` block. This approach is particularly readable and efficient when you want to check several things. See  `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_.
+Nonetheless, in many situations, you will do better using a simpler and more readable approach, that is, catching exceptions using the :code:`try-except` block. This approach is particularly readable and efficient when you want to check several things. See  `how to use in try-except blocks <https://github.com/nyggus/easycheck/blob/master/docs/use_with_try_doctest.rst>`_.

--- a/docs/use_with_try_doctest.rst
+++ b/docs/use_with_try_doctest.rst
@@ -43,6 +43,6 @@ You can get similar functionality using the function that catches exceptions, th
     Error: a must not be higher than b
     >>> foo(9, 10)
 
-Note that this code is much more complex than the above code. This is because we need to take care of *not* running :code:`catch_check(check_if_not, a > b, ValueError, 'a must not be higher than b')` if `a > b` gives an error (as does the comparison of an integer with a string). Using the :code:`catch_exception()` function, we need to catch each such check, something that the :code:`try-except` block did before. What's more, we did not format what :code:`print()` returns, since it would introduce additional complexity. 
+Note that this code is much more complex than the above code that uses the :code:`try-except` block. This is because we need to take care of *not* running :code:`catch_check(check_if_not, a > b, ValueError, 'a must not be higher than b')` if :code:`a > b` gives an error (as does the comparison of an integer with a string). Using the :code:`catch_exception()` function, we need to catch each such a check, something that the :code:`try-except` block did before for all the checks. What's more, we did not format what :code:`print()` returns, since it would introduce additional complexity. 
 
-As we see, in many instances the simpler approach with the :code:`try-except` block will be better and more readable.
+As we see, in many instances the simpler approach with the :code:`try-except` block will be better and more readable than using the :code:`catch_exception()` function.

--- a/docs/use_with_try_doctest.rst
+++ b/docs/use_with_try_doctest.rst
@@ -1,0 +1,48 @@
+Use with the try-except block
+-----------------------------
+
+You can use :code:`easycheck` functions within a :code:`try-except` block to catch exceptions. See:
+
+.. code-block:: python
+
+    >>> from easycheck import check_if_not, check_instance
+    >>> def foo(a, b):
+    ...    try:
+    ...        check_instance(a, int, message='a must be integer')
+    ...        check_instance(b, int, message='b must be integer')
+    ...        check_if_not(a > b, ValueError, 'a must not be higher than b')
+    ...    except Exception as e:
+    ...        print(f'Error: {e}')
+    >>> foo('string', 10)
+    Error: a must be integer
+    >>> foo(10, 'string')
+    Error: b must be integer
+    >>> foo(11, 10)
+    Error: a must not be higher than b
+    >>> foo(9, 10)
+
+You can get similar functionality using the function that catches exceptions, that is, :code:`catch_check()` (see `how to catch exceptions instead of raise them <https://github.com/nyggus/easycheck/blob/master/docs/catch_exceptions_doctest.rst>`_). In order to do so, you could do the following:
+
+.. code-block:: python
+
+    >>> from easycheck import check_if_not, check_instance, catch_check
+    >>> def bar(a, b):
+    ...    a_check = catch_check(check_instance, a, int, message='a must be integer')
+    ...    b_check = catch_check(check_instance, b, int, message='b must be integer')
+    ...    if not a_check and not b_check:
+    ...        a_b_check = catch_check(check_if_not, a > b, ValueError, 'a must not be higher than b')
+    ...        if a_b_check:
+    ...            print(f'Error: {a_b_check}')
+    ...    else:
+    ...        print(f'Error: {a_check}, {b_check}')
+    >>> bar('string', 10)
+    Error: a must be integer, None
+    >>> bar(10, 'string')
+    Error: None, b must be integer
+    >>> bar(11, 10)
+    Error: a must not be higher than b
+    >>> foo(9, 10)
+
+Note that this code is much more complex than the above code. This is because we need to take care of *not* running :code:`catch_check(check_if_not, a > b, ValueError, 'a must not be higher than b')` if `a > b` gives an error (as does the comparison of an integer with a string). Using the :code:`catch_exception()` function, we need to catch each such check, something that the :code:`try-except` block did before. What's more, we did not format what :code:`print()` returns, since it would introduce additional complexity. 
+
+As we see, in many instances the simpler approach with the :code:`try-except` block will be better and more readable.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name="easycheck",
-    version="0.1.0",
+    version="0.1.1",
     author="Nyggus & Ke Boan",
     author_email="nyggus@gmail.com",
     license='MIT',


### PR DESCRIPTION
* a doctest file is added to docs/ that shows an example of how to use `eachyckeck` functions in a `try-except` block
* docs README is updated
* a doctest file for catching exceptions is updated and links to the new doc file
* version updated (0.1.1)
* `blob` changed to `tree` in the main README in the call to the docs folder
* typos are corrected