### PR TITLE
Improve arg description for check argument

### DIFF
--- a/easycheck/easycheck.py
+++ b/easycheck/easycheck.py
@@ -184,8 +184,8 @@ def check_length(item,
     """Compare item's length with expected_length, using operator.
 
     Args:
-        item: the object whose type we want to validate
-        expected_length (int): the expected type of the item
+        item: the object whose length we want to validate
+        expected_length (int): the expected length of the item
         handle_with (type): the type of exception or warning to be raised
         message (str): a text to use as the exception/warning message
         operator: one of the functions returned by get_possible_operators()
@@ -553,7 +553,7 @@ def check_argument(argument,
             the default text 'argument'
         expected_type (type, Iterable[type]): the expected type of the item
         expected_choices (Iterable): a list of acceptable values of argument
-        expected_length (int): the expected type of the item
+        expected_length (int): the expected length of the item
         handle_with (type): the type of exception or warning to be raised
         message (str): a text to use as the exception/warning message
         **kwargs: additional arguments passed to check_length (i.e.,

--- a/easycheck/easycheck.py
+++ b/easycheck/easycheck.py
@@ -551,6 +551,13 @@ def check_argument(argument,
             function. If argument_name is not defined, the error messages will
             not include the name of the argument, but will instead only report
             the default text 'argument'
+        expected_type (type, Iterable[type]): the expected type of the item
+        expected_choices (Iterable): a list of acceptable values of argument
+        expected_length (int): the expected type of the item
+        handle_with (type): the type of exception or warning to be raised
+        message (str): a text to use as the exception/warning message
+        **kwargs: additional arguments passed to check_length (i.e.,
+            operator=eq and assign_length_to_others)
 
     Returns:
         None, if checks succeeded.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name="easycheck",
-    version="0.3.0",
+    version="0.3.1",
     author="Nyggus & Ke Boan",
     author_email="nyggus@gmail.com",
     license='MIT',


### PR DESCRIPTION
The docstring of `check_argument()` did not describe all the arguments; now it does.