### PR TITLE
Change check_instance/assert_instance with check_type/assert_type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ or you can use :code:`easycheck` for this:
 
 .. code-block:: python
 
-    check_instance(x, (float, int), message='x must be a number')
+    check_type(x, (float, int), message='x must be a number')
     check_if(x <= 10, ValueError, 'Too high value of x')
 
 The :code:`easycheck` approach has two main advantages over this classical approach:
@@ -38,7 +38,7 @@ The package also offers functions dedicated to testing, e.g.,
 
 .. code-block:: python
 
-    assert_instance(x, (float, int))
+    assert_type(x, (float, int))
     assert_if(x <= 10)
 
 Installing
@@ -84,9 +84,9 @@ Some other functions have different default errors; for instance, this call
 
 .. code-block:: python
 
-    check_instance(a, expected_type=str)
+    check_type(a, expected_type=str)
     # or shorter:
-    check_instance(a, str)
+    check_type(a, str)
 
 will raise :code:`TypeError` while this
 
@@ -101,7 +101,7 @@ Here is a list of :code:`easycheck` functions the module offers, along with thei
 * :code:`check_if()`, with the alias of :code:`assert_if()`
 * :code:`check_if_not()`, with the alias of :code:`assert_if_not()`
 * :code:`check_length()`, with the alias of :code:`assert_length()`
-* :code:`check_instance()`, with the alias of :code:`assert_instance()`
+* :code:`check_type()`, with the alias of :code:`assert_type()`
 * :code:`check_if_paths_exist()`, with the alias of :code:`assert_paths()`
 * :code:`check_comparison()` (used to compare two items)
 * :code:`check_all_ifs()` (used to check multiple conditions and return all the checks)
@@ -207,8 +207,8 @@ As mentioned above, most :code:`easycheck` functions have aliases to be used in 
         a, b = my_function_1(), my_function_2()
         
         assert_if(a == 2)
-        assert_instance(a, int)
-        assert_instance(b, tuple)
+        assert_type(a, int)
+        assert_type(b, tuple)
         assert_length(b, 5)
 
 Note that only the first one will raise :code:`AssertionError` while the others will raise more meaningful errors (:code:`TypeError` and :code:`LengthError`), which may better explain the reasons that the tests did not pass.

--- a/docs/catch_exceptions_doctest.rst
+++ b/docs/catch_exceptions_doctest.rst
@@ -5,7 +5,7 @@ If you do not want to raise exceptions but to catch them instead, you can do so 
 
 .. code-block:: python
 
-    >>> from easycheck import check_if, check_instance, catch_check
+    >>> from easycheck import check_if, check_type, catch_check
     >>> my_check = catch_check(check_if, 2 > 2, ValueError)
     >>> my_check
     ValueError()
@@ -14,7 +14,7 @@ If you do not want to raise exceptions but to catch them instead, you can do so 
     ValueError('Incorrect value')
     >>> type(my_check)
     <class 'ValueError'>
-    >>> check_instance(my_check, ValueError)
+    >>> check_type(my_check, ValueError)
     >>> raise(my_check)
     Traceback (most recent call last):
         ...

--- a/docs/general_description_doctest.rst
+++ b/docs/general_description_doctest.rst
@@ -7,9 +7,9 @@ Consider the following example:
 
 .. code-block:: python
 
-    >>> from easycheck import (check_if, check_if_not, check_length, check_instance,
+    >>> from easycheck import (check_if, check_if_not, check_length, check_type,
     ...                      check_comparison, check_if_paths_exist, assert_if, assert_length,
-    ...                      assert_instance)
+    ...                      assert_type)
     >>> if 1 > 0:
     ...    raise ValueError('One is bigger than zero')
     Traceback (most recent call last):
@@ -108,13 +108,13 @@ you can do the following:
 
 .. code-block:: python
 
-    >>> check_instance(my_string, str, message='This is not a string')
+    >>> check_type(my_string, str, message='This is not a string')
 
 If the condition is not met, it will raise :code:`TypeError`:
 
 .. code-block:: python
 
-    >>> check_instance('string', list, message='List is required here')
+    >>> check_type('string', list, message='List is required here')
     Traceback (most recent call last):
         ...
     TypeError: List is required here
@@ -155,7 +155,7 @@ The module also offers two-item comparisons, also using the operator parameter:
 Use in testing
 --------------
 
-The module offers assert-like functions, which are simply aliases of the corresponding easycheck functions: :code:`assert_if()`, :code:`assert_if_not()`, :code:`assert_instance()`, :code:`assert_length()` and :code:`assert_paths()`. You can use them in doctesting and pytesting, and their main advantage over the classical assertion expression is that they can use any exception you want, which makes testing output more informative. Also, due to the way they are written, you can design customized testing functions for particular situations.
+The module offers assert-like functions, which are simply aliases of the corresponding easycheck functions: :code:`assert_if()`, :code:`assert_if_not()`, :code:`assert_type()`, :code:`assert_length()` and :code:`assert_paths()`. You can use them in doctesting and pytesting, and their main advantage over the classical assertion expression is that they can use any exception you want, which makes testing output more informative. Also, due to the way they are written, you can design customized testing functions for particular situations.
 
 For instance, instead of
 
@@ -170,7 +170,7 @@ you can do the following:
 
 .. code-block:: python
 
-    >>> assert_instance(string, str)
+    >>> assert_type(string, str)
     >>> check_if_not(string == 'Silence prefered')
     >>> assert_length(string, 10, operator=gt)
 

--- a/docs/use_for_self_defined_functions_doctest.rst
+++ b/docs/use_for_self_defined_functions_doctest.rst
@@ -5,11 +5,11 @@ You can define complex checks using a function that collects calls to easycheck 
 
 .. code-block:: python
 
-    >>> from easycheck import check_if, check_instance, check_argument
+    >>> from easycheck import check_if, check_type, check_argument
     >>> def check_glm_args(glm_args):
-    ...    check_instance(glm_args[0], (int, float))
-    ...    check_instance(glm_args[1], str)
-    ...    check_instance(glm_args[2], str)
+    ...    check_type(glm_args[0], (int, float))
+    ...    check_type(glm_args[1], str)
+    ...    check_type(glm_args[2], str)
     ...    check_if(glm_args[0] > 0 and
     ...        glm_args[0] <= 1 and
     ...        glm_args[1] in ('poisson', 'quasi-poisson') and
@@ -34,11 +34,11 @@ We can do it in a more comprehensive way:
 
 .. code-block:: python
 
-    >>> from easycheck import check_if, check_instance
+    >>> from easycheck import check_if, check_type
     >>> def check_glm_args(glm_args):
-    ...    check_instance(glm_args[0], (int, float))
-    ...    check_instance(glm_args[1], str)
-    ...    check_instance(glm_args[2], str)
+    ...    check_type(glm_args[0], (int, float))
+    ...    check_type(glm_args[1], str)
+    ...    check_type(glm_args[2], str)
     ...    check_if(glm_args[0] > 0 and glm_args[0] <= 1,
     ...        handle_with=ValueError,
     ...        message='The first argument\'s value is incorrect'

--- a/docs/use_in_code_doctest.rst
+++ b/docs/use_in_code_doctest.rst
@@ -13,10 +13,10 @@ Here are several examples of the simplest uses of :code:`easycheck`:
 
 .. code-block:: python
 
-	>>> from easycheck import check_if, check_if_not, check_instance
+	>>> from easycheck import check_if, check_if_not, check_type
 	>>> def get_family_name(full_name):
 	...    check_if_not(full_name is None, TypeError, 'Missing name')
-	...    check_instance(full_name, str, message='Full name must be string')
+	...    check_type(full_name, str, message='Full name must be string')
 	...    check_if(' ' in full_name.strip(),
 	...        ValueError,
 	...        'No space in name: impossible to split first and second name'
@@ -61,7 +61,7 @@ Above, we used specified errors and messages, but we can make the call shorter b
 
 	>>> def get_family_name(full_name):
 	...    check_if_not(full_name is None, ValueError)
-	...    check_instance(full_name, str)
+	...    check_type(full_name, str)
 	...    check_if(' ' in full_name.strip(), ValueError)
 	...    return full_name.split(' ')[1]
 

--- a/docs/use_in_testing_doctest.rst
+++ b/docs/use_in_testing_doctest.rst
@@ -6,21 +6,21 @@ Although we stress that :code:`easycheck` functions are designed to be used with
 * :code:`assert_if` (for :code:`check_if`)
 * :code:`assert_if_not` (for :code:`check_if_not`)
 * :code:`assert_length` (for :code:`check_length`)
-* :code:`assert_instance` (for :code:`check_instance`)
+* :code:`assert_type` (for :code:`check_type`)
 * :code:`assert_paths` (for :code:`check_if_paths_exist`)
 
 As aliases, they use the same syntax and arguments as their :code:`easycheck` counterparts. See:
 
 .. code-block:: python
 
-    >>> from easycheck import assert_if, assert_instance, assert_length
+    >>> from easycheck import assert_if, assert_type, assert_length
     >>> def multiply_string(string, k):
     ...    """Make a list consisting of string k times.
     ...    >>> single_string = 'aka'
     ...    >>> string_multiplied = multiply_string(single_string, 3)
-    ...    >>> assert_instance(string_multiplied, list)
+    ...    >>> assert_type(string_multiplied, list)
     ...    >>> for i, item in enumerate(string_multiplied):
-    ...            assert_instance(item, str)
+    ...            assert_type(item, str)
     ...            assert_if(item == single_string)
     ...    >>> assert_length(string_multiplied, 3)
     ...    """
@@ -32,9 +32,9 @@ When you run doctests, all tests will run without error, as in the below simulat
 
     >>> single_string = 'aka'
     >>> string_multiplied = multiply_string(single_string, 3)
-    >>> assert_instance(string_multiplied, list)
+    >>> assert_type(string_multiplied, list)
     >>> for i, item in enumerate(string_multiplied):
-    ...    assert_instance(item, str)
+    ...    assert_type(item, str)
     ...    assert_if(item == single_string)
     >>> assert_length(string_multiplied, 3)
 

--- a/docs/use_with_try_doctest.rst
+++ b/docs/use_with_try_doctest.rst
@@ -5,11 +5,11 @@ You can use :code:`easycheck` functions within a :code:`try-except` block to cat
 
 .. code-block:: python
 
-    >>> from easycheck import check_if_not, check_instance
+    >>> from easycheck import check_if_not, check_type
     >>> def foo(a, b):
     ...    try:
-    ...        check_instance(a, int, message='a must be integer')
-    ...        check_instance(b, int, message='b must be integer')
+    ...        check_type(a, int, message='a must be integer')
+    ...        check_type(b, int, message='b must be integer')
     ...        check_if_not(a > b, ValueError, 'a must not be higher than b')
     ...    except Exception as e:
     ...        print(f'Error: {e}')
@@ -25,10 +25,10 @@ You can get similar functionality using the function that catches exceptions, th
 
 .. code-block:: python
 
-    >>> from easycheck import check_if_not, check_instance, catch_check
+    >>> from easycheck import check_if_not, check_type, catch_check
     >>> def bar(a, b):
-    ...    a_check = catch_check(check_instance, a, int, message='a must be integer')
-    ...    b_check = catch_check(check_instance, b, int, message='b must be integer')
+    ...    a_check = catch_check(check_type, a, int, message='a must be integer')
+    ...    b_check = catch_check(check_type, b, int, message='b must be integer')
     ...    if not a_check and not b_check:
     ...        a_b_check = catch_check(check_if_not, a > b, ValueError, 'a must not be higher than b')
     ...        if a_b_check:

--- a/docs/use_with_warnings_doctest.rst
+++ b/docs/use_with_warnings_doctest.rst
@@ -5,7 +5,7 @@ One of the aims of the :code:`easycheck` package is to enable you to issue a war
 
 .. code-block:: python
 
-    >>> from easycheck import check_if, check_instance, check_length
+    >>> from easycheck import check_if, check_type, check_length
     >>> check_if(2 > 2, Warning)
 
 This will raise a warning (of the :code:`Warning` class), with a default (and unhelpful) message 'Warning', leading to the warning :code:`Warning: Warning`. To change this (rather unhelpful) message, use the :code:`message` parameter, as below:
@@ -23,7 +23,7 @@ Let's check other examples, but this time we will catch the warnings in order to
     >>> import warnings
     >>> x = 50
     >>> with warnings.catch_warnings(record=True) as this_warning:
-    ...     check_instance(x, (tuple, list), Warning, 'Incorrect value')
+    ...     check_type(x, (tuple, list), Warning, 'Incorrect value')
     ...     assert 'Incorrect value' in str(this_warning[-1].message)
     ...     assert str(this_warning[-1].category) == "<class 'Warning'>"
 
@@ -38,7 +38,7 @@ You can use warnings in most :code:`easycheck` functions, and you can catch them
     ...    handle_with=Warning,
     ...    message='The list should be 5-element long')
     Warning('The list should be 5-element long')
-    >>> catch_check(check_instance,
+    >>> catch_check(check_type,
     ...    'some string but for sure not a float',
     ...    expected_type=float,
     ...    handle_with=Warning,

--- a/easycheck/__init__.py
+++ b/easycheck/__init__.py
@@ -1,21 +1,28 @@
-from .easycheck import (check_if,
-                      check_if_not,
-                      check_instance,
-                      check_if_paths_exist,
-                      check_length,
-                      check_all_ifs,
-                      check_argument,
-                      check_comparison,
-                      catch_check,
-                      ComparisonError,
-                      ArgumentValueError,
-                      LengthError,
-                      OperatorError,
-                      assert_if,
-                      assert_if_not,
-                      assert_length,
-                      assert_instance,
-                      assert_paths
-                      )
+from .easycheck import (
+    # functions
+    check_if,
+    check_if_not,
+    check_type,
+    check_if_paths_exist,
+    check_length,
+    check_all_ifs,
+    check_argument,
+    check_comparison,
+    catch_check,
+    # Exception classes
+    ComparisonError,
+    ArgumentValueError,
+    LengthError,
+    OperatorError,
+    # Testing aliases
+    assert_if,
+    assert_if_not,
+    assert_length,
+    assert_type,
+    assert_paths,
+    # Backward-compatibility aliases
+    check_instance,
+    assert_instance,
+)
 
 from operator import eq, le, lt, gt, ge, ne, is_, is_not

--- a/easycheck/easycheck.py
+++ b/easycheck/easycheck.py
@@ -8,7 +8,7 @@ expression, you can use easycheck functions within code.
 
 The module also offers aliases to be used in testing, all of which have the
 word "assert" in their names (assert_if(), assert_if_not(),
-assert_instance(), assert_length(), and assert_path()).
+assert_type(), assert_length(), and assert_path()).
 """
 import os
 import warnings
@@ -20,11 +20,13 @@ from pathlib import Path
 
 class LengthError(Exception):
     """Exception class used by the check_length() function."""
+
     pass
 
 
 class OperatorError(Exception):
     """Exception class used for catching incorrect operators."""
+
     pass
 
 
@@ -35,6 +37,7 @@ class ComparisonError(Exception):
     this class is ready for you to use in case you want to catch a customized
     error for comparison purposes.
     """
+
     pass
 
 
@@ -46,6 +49,7 @@ class ArgumentValueError(Exception):
     a dedicated exception. The function check_argument() uses this class as
     a default exception.
     """
+
     pass
 
 
@@ -107,9 +111,9 @@ def check_if(condition, handle_with=AssertionError, message=None):
 
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               condition=condition)
+    _check_easycheck_arguments(
+        handle_with=handle_with, message=message, condition=condition
+    )
     if not condition:
         _raise(handle_with, message)
 
@@ -117,70 +121,72 @@ def check_if(condition, handle_with=AssertionError, message=None):
 def check_if_not(condition, handle_with=AssertionError, message=None):
     """Check if a condition is not true.
 
-    Args:
-        condition (bool): condition to check.
-        handle_with (type): the type of exception or warning to be raised
-        message (str): a text to use as the exception/warning message
+        Args:
+            condition (bool): condition to check.
+            handle_with (type): the type of exception or warning to be raised
+            message (str): a text to use as the exception/warning message
 
-    Returns:
-        None, if check succeeded.
+        Returns:
+            None, if check succeeded.
 
-    Raises:
-        Exception of the type provided by the handle_with parameter,
-        AssertionError by default (unless handle_with is a warning).
+        Raises:
+            Exception of the type provided by the handle_with parameter,
+            AssertionError by default (unless handle_with is a warning).
 
-    You would normally use these functions in situations like these: This is
-    engine speed in the object engine_speed:
-    >>> engine_speed = 5900
+        You would normally use these functions in situations like these: This is
+        engine speed in the object engine_speed:
+        >>> engine_speed = 5900
 
-    In this case, assume that if this value is higher than 6000, than this
-    situation may cause problems. So, let us check this:
-:
-    >>> check_if_not(engine_speed > 6000, ValueError, 'Danger!')
+        In this case, assume that if this value is higher than 6000, than this
+        situation may cause problems. So, let us check this:
+    :
+        >>> check_if_not(engine_speed > 6000, ValueError, 'Danger!')
 
-    Sure, you can do so using the check_if() function, like here:
-    >>> check_if(engine_speed <= 6000, ValueError, 'Danger!')
+        Sure, you can do so using the check_if() function, like here:
+        >>> check_if(engine_speed <= 6000, ValueError, 'Danger!')
 
-    and both are fine. You simply have two functions to choose from in order to
-    make the code as readable as you want. Sometimes the negative version
-    sounds more natural, and so it's all about what kind of language you want
-    to use in this particular situation.
+        and both are fine. You simply have two functions to choose from in order to
+        make the code as readable as you want. Sometimes the negative version
+        sounds more natural, and so it's all about what kind of language you want
+        to use in this particular situation.
 
-    Consider the examples below:
-    >>> check_if_not(2 == 1)
-    >>> check_if_not(2 > 1)
-    Traceback (most recent call last):
-        ...
-    AssertionError
-    >>> check_if_not(2 > 1, ValueError, '2 is not smaller than 1')
-    Traceback (most recent call last):
-        ...
-    ValueError: 2 is not smaller than 1
+        Consider the examples below:
+        >>> check_if_not(2 == 1)
+        >>> check_if_not(2 > 1)
+        Traceback (most recent call last):
+            ...
+        AssertionError
+        >>> check_if_not(2 > 1, ValueError, '2 is not smaller than 1')
+        Traceback (most recent call last):
+            ...
+        ValueError: 2 is not smaller than 1
 
-    >>> BMI = 50
-    >>> disaster = True if BMI > 30 else False
-    >>> check_if_not(disaster, message='BMI disaster! Watch out for candies!')
-    Traceback (most recent call last):
-        ...
-    AssertionError: BMI disaster! Watch out for candies!
+        >>> BMI = 50
+        >>> disaster = True if BMI > 30 else False
+        >>> check_if_not(disaster, message='BMI disaster! Watch out for candies!')
+        Traceback (most recent call last):
+            ...
+        AssertionError: BMI disaster! Watch out for candies!
 
-    To issue a warning, use the Warning class or one of its subclasses:
-    >>> check_if_not(2 > 1, Warning, '2 is not bigger than 1')
+        To issue a warning, use the Warning class or one of its subclasses:
+        >>> check_if_not(2 > 1, Warning, '2 is not bigger than 1')
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               condition=condition)
+    _check_easycheck_arguments(
+        handle_with=handle_with, message=message, condition=condition
+    )
 
     check_if(not condition, handle_with=handle_with, message=message)
 
 
-def check_length(item,
-                 expected_length,
-                 handle_with=LengthError,
-                 message=None,
-                 operator=eq,
-                 assign_length_to_others=False):
+def check_length(
+    item,
+    expected_length,
+    handle_with=LengthError,
+    message=None,
+    operator=eq,
+    assign_length_to_others=False,
+):
     """Compare item's length with expected_length, using operator.
 
     Args:
@@ -216,11 +222,13 @@ def check_length(item,
     >>> check_length('string', 6, Warning)
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               operator=operator,
-                               expected_length=expected_length,
-                               assign_length_to_others=assign_length_to_others)
+    _check_easycheck_arguments(
+        handle_with=handle_with,
+        message=message,
+        operator=operator,
+        expected_length=expected_length,
+        assign_length_to_others=assign_length_to_others,
+    )
 
     if assign_length_to_others:
         if isinstance(item, (int, float, complex, bool)):
@@ -230,7 +238,7 @@ def check_length(item,
     check_if(condition_to_check, handle_with=handle_with, message=message)
 
 
-def check_instance(item, expected_type, handle_with=TypeError, message=None):
+def check_type(item, expected_type, handle_with=TypeError, message=None):
     """Check if item has the type of expected_type.
 
     Args:
@@ -251,43 +259,43 @@ def check_instance(item, expected_type, handle_with=TypeError, message=None):
     >>> check_if(my_none_object is None, handle_with=TypeError)
 
     or
-    >>> check_instance(my_none_object, None)
+    >>> check_type(my_none_object, None)
 
     None is not a type, but it gets special treatment so that you can use
-    the check_instance() function for None objects.
+    the check_type() function for None objects.
 
-    >>> check_instance(['string'], list)
-    >>> check_instance('string', str)
-    >>> check_instance((1, 2), tuple)
-    >>> check_instance([1, 2], (tuple, list), message='Neither tuple nor list')
-    >>> check_instance('souvenir',
+    >>> check_type(['string'], list)
+    >>> check_type('string', str)
+    >>> check_type((1, 2), tuple)
+    >>> check_type([1, 2], (tuple, list), message='Neither tuple nor list')
+    >>> check_type('souvenir',
     ...    (tuple, list),
     ...    message='Neither tuple nor list')
     Traceback (most recent call last):
         ...
     TypeError: Neither tuple nor list
-    >>> check_instance((i for i in range(3)), tuple)
+    >>> check_type((i for i in range(3)), tuple)
     Traceback (most recent call last):
         ...
     TypeError
-    >>> check_instance(
+    >>> check_type(
     ...    (i for i in range(3)), tuple, message='This is not tuple.')
     Traceback (most recent call last):
         ...
     TypeError: This is not tuple.
-    >>> check_instance((i for i in range(3)), Generator)
+    >>> check_type((i for i in range(3)), Generator)
 
     You can include None:
-    >>> check_instance('a', (str, None))
-    >>> check_instance(None, expected_type=(str, None))
+    >>> check_type('a', (str, None))
+    >>> check_type(None, expected_type=(str, None))
 
     To issue a warning, do the following:
-    >>> check_instance('a', (str, None), Warning, 'Undesired instance')
+    >>> check_type('a', (str, None), Warning, 'Undesired instance')
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               expected_type=expected_type)
+    _check_easycheck_arguments(
+        handle_with=handle_with, message=message, expected_type=expected_type
+    )
 
     if expected_type is None:
         check_if(item is None, handle_with=handle_with, message=message)
@@ -298,15 +306,16 @@ def check_instance(item, expected_type, handle_with=TypeError, message=None):
             return None
         expected_type = tuple(t for t in expected_type if t is not None)
 
-    check_if(isinstance(item, expected_type),
-             handle_with=handle_with,
-             message=message)
+    check_if(
+        isinstance(item, expected_type),
+        handle_with=handle_with,
+        message=message,
+    )
 
 
-def check_if_paths_exist(paths,
-                         handle_with=FileNotFoundError,
-                         message=None,
-                         execution_mode='raise'):
+def check_if_paths_exist(
+    paths, handle_with=FileNotFoundError, message=None, execution_mode="raise"
+):
     """Check if a path or paths exist.
 
     If it does not, either raise (or return) an exception or issue (or return)
@@ -360,23 +369,20 @@ def check_if_paths_exist(paths,
     (Warning('Attempt to use a non-existing path'), ['Q:/Op/Oop'])
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               execution_mode=execution_mode)
+    _check_easycheck_arguments(
+        handle_with=handle_with, message=message, execution_mode=execution_mode
+    )
 
-    is_allowed_type = (
-        isinstance(paths, (str, Path))
-        or (
-            isinstance(paths, Iterable)
-            and all(isinstance(path, (str, Path)) for path in paths)
-        )
+    is_allowed_type = isinstance(paths, (str, Path)) or (
+        isinstance(paths, Iterable)
+        and all(isinstance(path, (str, Path)) for path in paths)
     )
 
     check_if(
         is_allowed_type,
         TypeError,
-        'Argument paths must be string or pathlib.Path or iterable thereof'
-        )
+        "Argument paths must be string or pathlib.Path or iterable thereof",
+    )
 
     error = None
 
@@ -384,26 +390,25 @@ def check_if_paths_exist(paths,
         paths = (paths,)
 
     non_existing_paths = [
-        str(path) for path in paths
-        if not Path(path).exists()
+        str(path) for path in paths if not Path(path).exists()
     ]
 
     if non_existing_paths:
-        if execution_mode == 'raise':
+        if execution_mode == "raise":
             _raise(handle_with, message)
-        elif execution_mode == 'return':
+        elif execution_mode == "return":
             if message:
                 error = handle_with(str(message))
             else:
                 error = handle_with()
 
-    if execution_mode == 'return':
+    if execution_mode == "return":
         return error, non_existing_paths
 
 
-def check_comparison(item_1, operator, item_2,
-                     handle_with=ValueError,
-                     message=None):
+def check_comparison(
+    item_1, operator, item_2, handle_with=ValueError, message=None
+):
     """Check if a comparison of two items is true.
 
     Args:
@@ -447,13 +452,13 @@ def check_comparison(item_1, operator, item_2,
     ...                  message='Not less!')
     """
     __tracebackhide__ = True
-    _check_easycheck_arguments(handle_with=handle_with,
-                               message=message,
-                               operator=operator)
+    _check_easycheck_arguments(
+        handle_with=handle_with, message=message, operator=operator
+    )
 
-    check_if(operator(item_1, item_2),
-             handle_with=handle_with,
-             message=message)
+    check_if(
+        operator(item_1, item_2), handle_with=handle_with, message=message
+    )
 
 
 def check_all_ifs(*args):
@@ -507,16 +512,19 @@ def check_all_ifs(*args):
     {'1: check_if': True, '2: check_if_not': Warning('It might be wrong!')}
     """
     __tracebackhide__ = True
-    check_length(args, 0,
-                 operator=gt,
-                 handle_with=ValueError,
-                 message='Provide at least one condition.')
+    check_length(
+        args,
+        0,
+        operator=gt,
+        handle_with=ValueError,
+        message="Provide at least one condition.",
+    )
     tuple_error_message = (
-        'Provide all function calls as tuples in the form of '
-        '(check_function, *args)'
+        "Provide all function calls as tuples in the form of "
+        "(check_function, *args)"
     )
     for arg in args:
-        check_instance(arg, tuple, message=tuple_error_message)
+        check_type(arg, tuple, message=tuple_error_message)
 
     results_of_checks = dict()
     for i, this_check in enumerate(args):
@@ -530,19 +538,21 @@ def check_all_ifs(*args):
         except Exception as e:
             run_this_check = e
 
-        results_of_checks[f'{i + 1}: {function.__name__}'] = run_this_check
+        results_of_checks[f"{i + 1}: {function.__name__}"] = run_this_check
 
     return results_of_checks
 
 
-def check_argument(argument,
-                   argument_name=None,
-                   expected_type=None,
-                   expected_choices=None,
-                   expected_length=None,
-                   handle_with=ArgumentValueError,
-                   message=None,
-                   **kwargs):
+def check_argument(
+    argument,
+    argument_name=None,
+    expected_type=None,
+    expected_choices=None,
+    expected_length=None,
+    handle_with=ArgumentValueError,
+    message=None,
+    **kwargs,
+):
     """Check if the user provided a correct argument value.
 
     Args:
@@ -616,48 +626,65 @@ def check_argument(argument,
     ...    message="Incorrect argument's value")
     """
     __tracebackhide__ = True
-    if all(item is None
-           for item in (expected_type,
-                        expected_choices,
-                        expected_length
-                        )):
-        raise ValueError('check_argument() requires at least one condition'
-                         ' to be checked')
+    if all(
+        item is None
+        for item in (expected_type, expected_choices, expected_length)
+    ):
+        raise ValueError(
+            "check_argument() requires at least one condition" " to be checked"
+        )
 
     if argument_name is None:
-        argument_name = 'argument'
-    check_instance(argument_name,
-                   str,
-                   handle_with=handle_with,
-                   message='argument_name must be string')
+        argument_name = "argument"
+    check_type(
+        argument_name,
+        str,
+        handle_with=handle_with,
+        message="argument_name must be string",
+    )
 
     if expected_type is not None:
         instance_message = _make_message(
             message,
-            (f'Incorrect type of {argument_name}; valid type(s):'
-             f' {expected_type}'))
-        check_instance(item=argument,
-                       expected_type=expected_type,
-                       handle_with=handle_with,
-                       message=instance_message)
+            (
+                f"Incorrect type of {argument_name}; valid type(s):"
+                f" {expected_type}"
+            ),
+        )
+        check_type(
+            item=argument,
+            expected_type=expected_type,
+            handle_with=handle_with,
+            message=instance_message,
+        )
     if expected_choices is not None:
         choices_message = _make_message(
             message,
-            (f'{argument_name}\'s value, {argument}, '
-             f'is not among valid values: {expected_choices}.'))
-        check_if(argument in expected_choices,
-                 handle_with=handle_with,
-                 message=choices_message)
+            (
+                f"{argument_name}'s value, {argument}, "
+                f"is not among valid values: {expected_choices}."
+            ),
+        )
+        check_if(
+            argument in expected_choices,
+            handle_with=handle_with,
+            message=choices_message,
+        )
     if expected_length is not None:
         length_message = _make_message(
             message,
-            (f'Unexpected length of {argument_name}'
-             f' (should be {expected_length})'))
-        check_length(item=argument,
-                     expected_length=expected_length,
-                     handle_with=handle_with,
-                     message=length_message,
-                     **kwargs)
+            (
+                f"Unexpected length of {argument_name}"
+                f" (should be {expected_length})"
+            ),
+        )
+        check_length(
+            item=argument,
+            expected_length=expected_length,
+            handle_with=handle_with,
+            message=length_message,
+            **kwargs,
+        )
 
 
 def _make_message(message_provided, message_otherwise):
@@ -713,7 +740,7 @@ def catch_check(check_function, *args, **kwargs):
     ValueError()
     >>> type(my_check)
     <class 'ValueError'>
-    >>> check_instance(my_check, ValueError)
+    >>> check_type(my_check, ValueError)
     >>> raise(my_check)
     Traceback (most recent call last):
         ...
@@ -725,12 +752,12 @@ def catch_check(check_function, *args, **kwargs):
     >>> catch_check(check_length, [2, 2], 3)
     LengthError()
     >>> my_check = catch_check(
-    ...    check_instance, 25, float, ValueError, 'This is no float!')
+    ...    check_type, 25, float, ValueError, 'This is no float!')
     >>> my_check # doctest: +ELLIPSIS
     ValueError('This is no float!'...
     >>> print(str(my_check))
     This is no float!
-    >>> my_check = catch_check(check_instance, 'a', int)
+    >>> my_check = catch_check(check_type, 'a', int)
     >>> my_check
     TypeError()
     >>> raise(my_check)
@@ -748,42 +775,55 @@ def catch_check(check_function, *args, **kwargs):
     UserWarning('Beware of this problem')
     """
     __tracebackhide__ = True
-    check_if(isinstance(check_function, Callable),
-             handle_with=TypeError,
-             message=(f'{check_function} does not '
-                      'seem to be a easycheck function')
-             )
-    check_if_not(check_function == check_all_ifs,
-                 handle_with=ValueError,
-                 message=('Do not use catch_check for check_all_ifs() '
-                          'because it itself returns its checks.')
-                 )
-    paths_condition = (
-        check_function == check_if_paths_exist
-        and
-        ('return' in args or kwargs.get('execution_mode', '') == 'return')
+    check_if(
+        isinstance(check_function, Callable),
+        handle_with=TypeError,
+        message=(
+            f"{check_function} does not " "seem to be a easycheck function"
+        ),
     )
-    check_if_not(paths_condition,
-                 handle_with=ValueError,
-                 message=('Do not use catch_check for check_if_paths_exist() '
-                          'with execution_mode="return" because it itself '
-                          'returns its checks.')
-                 )
+    check_if_not(
+        check_function == check_all_ifs,
+        handle_with=ValueError,
+        message=(
+            "Do not use catch_check for check_all_ifs() "
+            "because it itself returns its checks."
+        ),
+    )
+    paths_condition = check_function == check_if_paths_exist and (
+        "return" in args or kwargs.get("execution_mode", "") == "return"
+    )
+    check_if_not(
+        paths_condition,
+        handle_with=ValueError,
+        message=(
+            "Do not use catch_check for check_if_paths_exist() "
+            'with execution_mode="return" because it itself '
+            "returns its checks."
+        ),
+    )
     check_argument(
         argument=check_function,
         argument_name=check_function.__name__,
         expected_choices=(
-            check_if, assert_if,
-            check_if_not, assert_if_not,
+            check_if,
+            assert_if,
+            check_if_not,
+            assert_if_not,
             check_argument,
             check_comparison,
-            check_if_paths_exist, assert_paths,
-            check_instance, assert_instance,
-            check_length, assert_length,
+            check_if_paths_exist,
+            assert_paths,
+            check_type,
+            assert_type,
+            check_length,
+            assert_length,
         ),
         handle_with=ArgumentValueError,
-        message=(f'{check_function.__name__} is not'
-                 ' among acceptable valid easycheck functions')
+        message=(
+            f"{check_function.__name__} is not"
+            " among acceptable valid easycheck functions"
+        ),
     )
 
     try:
@@ -833,29 +873,31 @@ def _raise(error, message=None):
     """
     __tracebackhide__ = True
     if not isinstance(error, type) or not issubclass(error, Exception):
-        raise TypeError('The error argument must be an exception or a warning')
+        raise TypeError("The error argument must be an exception or a warning")
 
     if issubclass(error, Warning):
         if message is None:
-            message = 'Warning'
-        check_instance(message, str, message='message must be string')
+            message = "Warning"
+        check_type(message, str, message="message must be string")
         warnings.warn(message, error)
     else:
         if message is None:
             raise error
         else:
-            check_instance(message, str, message='message must be string')
+            check_type(message, str, message="message must be string")
             raise error(message)
 
 
-def _check_easycheck_arguments(handle_with=None,
-                               message=None,
-                               condition=None,
-                               operator=None,
-                               assign_length_to_others=None,
-                               execution_mode=None,
-                               expected_length=None,
-                               expected_type=None):
+def _check_easycheck_arguments(
+    handle_with=None,
+    message=None,
+    condition=None,
+    operator=None,
+    assign_length_to_others=None,
+    execution_mode=None,
+    expected_length=None,
+    expected_type=None,
+):
     """Validate the most common arguments used in easycheck functions.
 
     This is a generic function that works for most easycheck functions, and can
@@ -879,17 +921,20 @@ def _check_easycheck_arguments(handle_with=None,
     >>> _check_easycheck_arguments(handle_with=ValueError, condition=2<1)
     """
     __tracebackhide__ = True
-    if all(argument is None
-           for argument
-           in (handle_with,
-               message,
-               condition,
-               operator,
-               assign_length_to_others,
-               execution_mode,
-               expected_length,
-               expected_type)):
-        raise ValueError('Provide at least one argument')
+    if all(
+        argument is None
+        for argument in (
+            handle_with,
+            message,
+            condition,
+            operator,
+            assign_length_to_others,
+            execution_mode,
+            expected_length,
+            expected_type,
+        )
+    ):
+        raise ValueError("Provide at least one argument")
 
     if handle_with is not None:
         try:
@@ -897,37 +942,43 @@ def _check_easycheck_arguments(handle_with=None,
         except TypeError:
             is_subclass = False
         if not is_subclass:
-            raise TypeError('handle_with must be an exception')
+            raise TypeError("handle_with must be an exception")
     if message is not None:
         if not isinstance(message, str):
-            raise TypeError('message must be either None or string')
+            raise TypeError("message must be either None or string")
     if condition is not None:
         if not isinstance(condition, bool):
-            raise ValueError('The condition does not return a boolean value')
+            raise ValueError("The condition does not return a boolean value")
     if operator is not None:
         if operator not in get_possible_operators():
             raise OperatorError(
-                'Incorrect operator. Check get_possible_operators()')
+                "Incorrect operator. Check get_possible_operators()"
+            )
     if expected_length is not None:
         if not isinstance(expected_length, (int, float)):
             raise TypeError(
-                'expected_length should be an integer (or a float)')
+                "expected_length should be an integer (or a float)"
+            )
     if assign_length_to_others is not None:
         if not isinstance(assign_length_to_others, bool):
-            raise TypeError('assign_length_to_others should be'
-                            ' a boolean value')
+            raise TypeError(
+                "assign_length_to_others should be" " a boolean value"
+            )
     if execution_mode is not None:
-        if execution_mode not in ('raise', 'return'):
+        if execution_mode not in ("raise", "return"):
             raise ValueError(
-                'execution_mode should be either "raise" or "return"')
+                'execution_mode should be either "raise" or "return"'
+            )
     if expected_type is not None:
         if isinstance(expected_type, Iterable):
-            if any(not isinstance(t, type)
-                   for t in expected_type
-                   if t is not None):
-                raise TypeError('all items in expected_type must be valid types')
+            if any(
+                not isinstance(t, type) for t in expected_type if t is not None
+            ):
+                raise TypeError(
+                    "all items in expected_type must be valid types"
+                )
         elif not isinstance(expected_type, type):
-            raise TypeError('expected_type must be a valid type')
+            raise TypeError("expected_type must be a valid type")
 
 
 def get_possible_operators():
@@ -950,5 +1001,11 @@ def get_possible_operators():
 assert_if = check_if
 assert_if_not = check_if_not
 assert_length = check_length
-assert_instance = check_instance
+assert_type = check_type
 assert_paths = check_if_paths_exist
+
+
+# Alias to ensure backward compatibility
+
+check_instance = check_type
+assert_instance = assert_type

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 extras_requirements = {
-    "dev": ["pytest==7.0.1", "wheel==0.37.1", ],
+    "dev": ["pytest", "wheel", "black"],
 }
 
 setuptools.setup(
     name="easycheck",
-    version="0.3.2",
+    version="0.3.3",
     author="Nyggus & Ke Boan",
     author_email="nyggus@gmail.com",
     license="MIT",
@@ -30,6 +30,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     extras_require=extras_requirements,
 )

--- a/tests/test_easycheck.py
+++ b/tests/test_easycheck.py
@@ -4,45 +4,53 @@ import pytest
 from collections.abc import Generator
 from operator import eq, le, lt, gt, ge, ne, is_, is_not
 from pathlib import Path
-from easycheck.easycheck import (check_if, assert_if,
-                                 check_if_not, assert_if_not,
-                                 check_instance, assert_instance,
-                                 check_if_paths_exist, assert_paths,
-                                 check_length, assert_length,
-                                 check_all_ifs,
-                                 check_argument,
-                                 check_comparison,
-                                 catch_check,
-                                 ComparisonError,
-                                 ArgumentValueError,
-                                 LengthError,
-                                 OperatorError,
-                                 get_possible_operators,
-                                 _raise,
-                                 _check_easycheck_arguments,
-                                 _make_message,
-                                 )
+from easycheck.easycheck import (
+    check_if,
+    assert_if,
+    check_if_not,
+    assert_if_not,
+    check_type,
+    assert_type,
+    check_if_paths_exist,
+    assert_paths,
+    check_length,
+    assert_length,
+    check_all_ifs,
+    check_argument,
+    check_comparison,
+    catch_check,
+    ComparisonError,
+    ArgumentValueError,
+    LengthError,
+    OperatorError,
+    get_possible_operators,
+    _raise,
+    _check_easycheck_arguments,
+    _make_message,
+)
 
 
 def test_check_if_edge_cases():
     with pytest.raises(TypeError, match="required positional argument"):
         check_if()
-    with pytest.raises(ValueError, match='The condition does not return'):
-        check_if('tomato soup is good')
-    with pytest.raises(ValueError, match='The condition does not return'):
-        check_if('')
-    with pytest.raises(ValueError, match='The condition does not return'):
+    with pytest.raises(ValueError, match="The condition does not return"):
+        check_if("tomato soup is good")
+    with pytest.raises(ValueError, match="The condition does not return"):
+        check_if("")
+    with pytest.raises(ValueError, match="The condition does not return"):
         check_if(1)
-    with pytest.raises(ValueError, match='The condition does not return'):
+    with pytest.raises(ValueError, match="The condition does not return"):
         check_if(0)
     assert check_if(True) is None
     with pytest.raises(AssertionError):
         check_if(False)
-    with pytest.raises(TypeError, match='handle_with must be an exception'):
+    with pytest.raises(TypeError, match="handle_with must be an exception"):
         check_if(1, 1)
-    with pytest.raises(TypeError, match='message must be either None or string'):
+    with pytest.raises(
+        TypeError, match="message must be either None or string"
+    ):
         check_if(1, ValueError, 1)
-    with pytest.raises(TypeError, match='takes from 1 to 3 positional'):
+    with pytest.raises(TypeError, match="takes from 1 to 3 positional"):
         check_if(1, 1, 1, 1)
 
 
@@ -60,48 +68,50 @@ def test_check_if_negative():
         check_if(2 < 1)
     with pytest.raises(ValueError):
         check_if(2 < 1, handle_with=ValueError)
-    with pytest.raises(ValueError, match='incorrect value'):
-        check_if(2 < 1, handle_with=ValueError, message='incorrect value')
+    with pytest.raises(ValueError, match="incorrect value"):
+        check_if(2 < 1, handle_with=ValueError, message="incorrect value")
 
 
 def test_check_if_negative_warnings():
     with warnings.catch_warnings(record=True) as w:
-        check_if(2 < 1, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_if(2 < 1, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_if(2 < 1, UserWarning, 'This is a testing warning')
+        check_if(2 < 1, UserWarning, "This is a testing warning")
         assert issubclass(w[-1].category, Warning)
-        assert 'This is a testing warning' in str(w[-1].message)
+        assert "This is a testing warning" in str(w[-1].message)
 
 
 def test_check_if_not_edge_cases():
     with pytest.raises(TypeError, match="required positional argument"):
         check_if_not()
-    with pytest.raises(ValueError, match='The condition does not return'):
-        check_if_not('tomato soup is good')
-    with pytest.raises(ValueError, match='The condition does not return'):
-        check_if_not('')
-    with pytest.raises(ValueError, match='The condition does not return'):
+    with pytest.raises(ValueError, match="The condition does not return"):
+        check_if_not("tomato soup is good")
+    with pytest.raises(ValueError, match="The condition does not return"):
+        check_if_not("")
+    with pytest.raises(ValueError, match="The condition does not return"):
         check_if_not(1)
-    with pytest.raises(ValueError, match='The condition does not return'):
+    with pytest.raises(ValueError, match="The condition does not return"):
         check_if_not(0)
     assert check_if_not(False) is None
     with pytest.raises(AssertionError):
         check_if_not(True)
-    with pytest.raises(TypeError, match='handle_with must be an exception'):
+    with pytest.raises(TypeError, match="handle_with must be an exception"):
         check_if_not(1, 1)
-    with pytest.raises(TypeError, match='message must be either None or string'):
+    with pytest.raises(
+        TypeError, match="message must be either None or string"
+    ):
         check_if_not(1, ValueError, 1)
-    with pytest.raises(TypeError, match='takes from 1 to 3 positional'):
+    with pytest.raises(TypeError, match="takes from 1 to 3 positional"):
         check_if_not(1, 1, 1, 1)
 
 
 def test_check_if_not_positive():
     assert check_if_not(2 < 1) is None
     assert check_if_not(2 < 1, Warning) is None
-    assert check_if_not('a' == 'A') is None
-    assert check_if_not('a' == 'A', Warning) is None
+    assert check_if_not("a" == "A") is None
+    assert check_if_not("a" == "A", Warning) is None
 
 
 def test_check_if_not_negative():
@@ -109,42 +119,42 @@ def test_check_if_not_negative():
         check_if_not(2 > 1)
     with pytest.raises(ValueError):
         check_if_not(2 > 1, handle_with=ValueError)
-    with pytest.raises(ValueError, match='incorrect value'):
-        check_if_not(2 > 1, handle_with=ValueError, message='incorrect value')
+    with pytest.raises(ValueError, match="incorrect value"):
+        check_if_not(2 > 1, handle_with=ValueError, message="incorrect value")
 
 
 def test_check_if_not_negative_warnings():
     with warnings.catch_warnings(record=True) as w:
-        check_if_not(2 > 1, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_if_not(2 > 1, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_if_not(2 > 1, UserWarning, 'This is a testing warning')
+        check_if_not(2 > 1, UserWarning, "This is a testing warning")
         assert issubclass(w[-1].category, Warning)
-        assert 'This is a testing warning' in str(w[-1].message)
+        assert "This is a testing warning" in str(w[-1].message)
 
 
 def test_check_length_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
-        check_length('tomato soup is good')
-    with pytest.raises(OperatorError, match='Incorrect operator'):
+    with pytest.raises(TypeError, match="required positional argument"):
+        check_length("tomato soup is good")
+    with pytest.raises(OperatorError, match="Incorrect operator"):
         check_length(1, 1, operator=1)
 
 
 def test_check_length_positive():
-    assert check_length(['string'], 1) is None
-    assert check_length(['string'], 1, handle_with=Warning) is None
-    assert check_length('string', 6) is None
-    assert check_length('string', 6, handle_with=Warning) is None
+    assert check_length(["string"], 1) is None
+    assert check_length(["string"], 1, handle_with=Warning) is None
+    assert check_length("string", 6) is None
+    assert check_length("string", 6, handle_with=Warning) is None
     assert check_length([1, 2], 2) is None
     assert check_length([1, 2], 2, handle_with=Warning) is None
     assert check_length(range(0, 3), 3) is None
     assert check_length(range(0, 3), 3, handle_with=Warning) is None
     assert check_length(10, 1, assign_length_to_others=True) is None
-    assert check_length(10,
-                        1,
-                        assign_length_to_others=True,
-                        handle_with=Warning) is None
+    assert (
+        check_length(10, 1, assign_length_to_others=True, handle_with=Warning)
+        is None
+    )
 
 
 def test_check_length_negative():
@@ -158,115 +168,119 @@ def test_check_length_negative():
 
 def test_check_length_negative_warnings():
     with warnings.catch_warnings(record=True) as w:
-        check_length([1, 2],
-                     expected_length=1,
-                     handle_with=Warning,
-                     message='This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_length(
+            [1, 2],
+            expected_length=1,
+            handle_with=Warning,
+            message="This is a testing warning",
+        )
+        assert "This is a testing warning" in str(w[-1].message)
 
 
-def test_check_instance_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
-        check_instance('tomato soup is good')
+def test_check_type_edge_cases():
+    with pytest.raises(TypeError, match="required positional argument"):
+        check_type("tomato soup is good")
 
 
-def test_check_instance_positive():
-    assert check_instance(['string'], list) is None
-    assert check_instance(['string'], list, handle_with=Warning) is None
-    assert check_instance('string', str) is None
-    assert check_instance('string', str, handle_with=Warning) is None
-    assert check_instance((1, 2), tuple) is None
-    assert check_instance((1, 2), tuple, handle_with=Warning) is None
-    assert check_instance((1, 2), [tuple, list]) is None
-    assert check_instance((1, 2), [tuple, list], handle_with=Warning) is None
-    assert check_instance((1, 2), [list, tuple]) is None
-    assert check_instance((1, 2), {tuple, list}, handle_with=Warning) is None
-    assert check_instance(
-        (1, 2), (tuple, list),
-        message='Neither tuple nor list'
-    ) is None
-    assert check_instance(
-        (1, 2), (tuple, list),
-        message='Neither tuple nor list',
-        handle_with=Warning
-    ) is None
-    assert check_instance((i for i in range(3)), Generator) is None
-    assert check_instance((i for i in range(3)),
-                          Generator,
-                          handle_with=Warning) is None
-    assert check_instance(None, (int, None)) is None
-    assert check_instance(None, (int, None), handle_with=Warning) is None
-    assert check_instance(20, (int, None)) is None
-    assert check_instance(20, (int, None), handle_with=Warning) is None
-    assert check_instance(None, None) is None
-    assert check_instance(None, None, handle_with=Warning) is None
+def test_check_type_positive():
+    assert check_type(["string"], list) is None
+    assert check_type(["string"], list, handle_with=Warning) is None
+    assert check_type("string", str) is None
+    assert check_type("string", str, handle_with=Warning) is None
+    assert check_type((1, 2), tuple) is None
+    assert check_type((1, 2), tuple, handle_with=Warning) is None
+    assert check_type((1, 2), [tuple, list]) is None
+    assert check_type((1, 2), [tuple, list], handle_with=Warning) is None
+    assert check_type((1, 2), [list, tuple]) is None
+    assert check_type((1, 2), {tuple, list}, handle_with=Warning) is None
+    assert (
+        check_type((1, 2), (tuple, list), message="Neither tuple nor list")
+        is None
+    )
+    assert (
+        check_type(
+            (1, 2),
+            (tuple, list),
+            message="Neither tuple nor list",
+            handle_with=Warning,
+        )
+        is None
+    )
+    assert check_type((i for i in range(3)), Generator) is None
+    assert (
+        check_type((i for i in range(3)), Generator, handle_with=Warning)
+        is None
+    )
+    assert check_type(None, (int, None)) is None
+    assert check_type(None, (int, None), handle_with=Warning) is None
+    assert check_type(20, (int, None)) is None
+    assert check_type(20, (int, None), handle_with=Warning) is None
+    assert check_type(None, None) is None
+    assert check_type(None, None, handle_with=Warning) is None
 
 
-def test_check_instance_negative():
-    with pytest.raises(TypeError, match='Neither tuple nor list'):
-        check_instance('souvenir',
-                       (tuple, list),
-                       message='Neither tuple nor list')
+def test_check_type_negative():
+    with pytest.raises(TypeError, match="Neither tuple nor list"):
+        check_type("souvenir", (tuple, list), message="Neither tuple nor list")
     with pytest.raises(TypeError):
-        check_instance('souvenir', [tuple, list])
+        check_type("souvenir", [tuple, list])
     with pytest.raises(TypeError):
-        check_instance('souvenir', {tuple, list})
+        check_type("souvenir", {tuple, list})
     with pytest.raises(TypeError):
-        check_instance(True, (str, complex))
+        check_type(True, (str, complex))
     with pytest.raises(TypeError):
-        check_instance(20.1, (int, None))
+        check_type(20.1, (int, None))
     with pytest.raises(TypeError):
-        check_instance((i for i in range(3)), tuple)
-    with pytest.raises(TypeError, match='This is not tuple'):
-        check_instance((i for i in range(3)),
-                       tuple,
-                       message='This is not tuple')
+        check_type((i for i in range(3)), tuple)
+    with pytest.raises(TypeError, match="This is not tuple"):
+        check_type((i for i in range(3)), tuple, message="This is not tuple")
     with pytest.raises(TypeError):
-        check_instance(10, None)
+        check_type(10, None)
     with pytest.raises(TypeError):
-        check_instance('string', None)
+        check_type("string", None)
     with pytest.raises(TypeError):
-        check_instance((10, 20), None)
+        check_type((10, 20), None)
     with pytest.raises(TypeError):
-        check_instance([10, 20], None)
+        check_type([10, 20], None)
 
 
-def test_check_instance_negative_warnings():
+def test_check_type_negative_warnings():
     with warnings.catch_warnings(record=True) as w:
-        check_instance(
-            'souvenir',
+        check_type(
+            "souvenir",
             (tuple, list),
             handle_with=Warning,
-            message='This is a testing warning'
+            message="This is a testing warning",
         )
-        assert 'This is a testing warning' in str(w[-1].message)
+        assert "This is a testing warning" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_instance(
+        check_type(
             True,
             [str, complex],
             handle_with=Warning,
-            message='This is a testing warning'
+            message="This is a testing warning",
         )
-        assert 'This is a testing warning' in str(w[-1].message)
+        assert "This is a testing warning" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_instance(
+        check_type(
             20.1,
             (int, None),
             handle_with=Warning,
-            message='This is a testing warning'
+            message="This is a testing warning",
         )
-        assert 'This is a testing warning' in str(w[-1].message)
+        assert "This is a testing warning" in str(w[-1].message)
 
 
 def test_catch_check_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
-        catch_check(check=check_instance)
-    with pytest.raises(TypeError, match='easycheck function'):
+    with pytest.raises(TypeError, match="required positional argument"):
+        catch_check(check=check_type)
+    with pytest.raises(TypeError, match="easycheck function"):
         catch_check(1)
-    with pytest.raises(ArgumentValueError,
-                       match='acceptable valid easycheck functions'):
+    with pytest.raises(
+        ArgumentValueError, match="acceptable valid easycheck functions"
+    ):
         catch_check(sum)
 
 
@@ -281,7 +295,7 @@ def test_catch_check_if():
     with pytest.raises(AssertionError):
         raise my_check_not
 
-    my_check_not = catch_check(check_if, 2 > 2, UserWarning, 'Problem!')
+    my_check_not = catch_check(check_if, 2 > 2, UserWarning, "Problem!")
     assert isinstance(my_check_not, Warning)
 
     my_check_not = catch_check(check_if, 2 > 2, ValueError)
@@ -297,7 +311,7 @@ def test_catch_check_if_not():
     my_check = catch_check(check_if_not, 2 > 2)
     assert my_check is None
 
-    my_check = catch_check(check_if_not, 2 > 2, Warning, 'Problem!')
+    my_check = catch_check(check_if_not, 2 > 2, Warning, "Problem!")
     assert my_check is None
 
     my_check_not = catch_check(check_if_not, 2 == 2)
@@ -305,10 +319,9 @@ def test_catch_check_if_not():
     with pytest.raises(AssertionError):
         raise my_check_not
 
-    my_check_not = catch_check(check_if_not,
-                               2 == 2,
-                               handle_with=Warning,
-                               message='Problem!')
+    my_check_not = catch_check(
+        check_if_not, 2 == 2, handle_with=Warning, message="Problem!"
+    )
     assert isinstance(my_check_not, Warning)
 
 
@@ -316,11 +329,13 @@ def test_catch_check_length():
     my_check = catch_check(check_length, [2, 2], 2)
     assert my_check is None
 
-    my_check = catch_check(check_length,
-                           [2, 2],
-                           expected_length=2,
-                           handle_with=Warning,
-                           message='Length problem')
+    my_check = catch_check(
+        check_length,
+        [2, 2],
+        expected_length=2,
+        handle_with=Warning,
+        message="Length problem",
+    )
     assert my_check is None
 
     my_check_not = catch_check(check_length, [2, 2], 3)
@@ -328,110 +343,84 @@ def test_catch_check_length():
     with pytest.raises(LengthError):
         raise my_check_not
 
-    my_check = catch_check(check_length,
-                           [2, 2],
-                           expected_length=3,
-                           handle_with=Warning,
-                           message='Length problem')
+    my_check = catch_check(
+        check_length,
+        [2, 2],
+        expected_length=3,
+        handle_with=Warning,
+        message="Length problem",
+    )
     assert isinstance(my_check, Warning)
-    assert 'Length problem' in str(my_check)
+    assert "Length problem" in str(my_check)
 
 
-def test_catch_check_instance():
-    my_check = catch_check(check_instance, 25, int)
+def test_catch_check_type():
+    my_check = catch_check(check_type, 25, int)
     assert my_check is None
 
-    my_check = catch_check(check_instance, 25, int, Warning, 'Instance issue')
+    my_check = catch_check(check_type, 25, int, Warning, "Instance issue")
     assert my_check is None
 
-    my_check_not = catch_check(check_instance,
-                               25,
-                               float,
-                               ValueError,
-                               'This is no float!')
+    my_check_not = catch_check(
+        check_type, 25, float, ValueError, "This is no float!"
+    )
     assert isinstance(my_check_not, ValueError)
-    with pytest.raises(ValueError, match='This is no float!'):
+    with pytest.raises(ValueError, match="This is no float!"):
         raise my_check_not
 
-    my_check = catch_check(check_instance, 25, float,
-                           Warning, 'Instance issue')
+    my_check = catch_check(check_type, 25, float, Warning, "Instance issue")
     assert isinstance(my_check, Warning)
 
-    my_check = catch_check(check_instance, 'a', int)
+    my_check = catch_check(check_type, "a", int)
     assert isinstance(my_check, TypeError)
     with pytest.raises(TypeError):
         raise my_check
 
 
 def test_catch_check_paths_with_return():
-    existing_path = os.listdir('.')[0]
+    existing_path = os.listdir(".")[0]
     with pytest.raises(ValueError, match='execution_mode="return"'):
-        catch_check(check_if_paths_exist,
-                    paths=existing_path,
-                    execution_mode='return')
+        catch_check(
+            check_if_paths_exist, paths=existing_path, execution_mode="return"
+        )
     with pytest.raises(ValueError, match='execution_mode="return"'):
-        catch_check(check_if_paths_exist,
-                    existing_path,
-                    FileNotFoundError,
-                    'Path not found',
-                    'return')
+        catch_check(
+            check_if_paths_exist,
+            existing_path,
+            FileNotFoundError,
+            "Path not found",
+            "return",
+        )
 
 
 def test_catch_check_paths_one_path():
-    existing_path = os.listdir('.')[0]
+    existing_path = os.listdir(".")[0]
     my_check = catch_check(check_if_paths_exist, paths=existing_path)
-    my_check_path = catch_check(check_if_paths_exist, paths=Path(existing_path))
+    my_check_path = catch_check(
+        check_if_paths_exist, paths=Path(existing_path)
+    )
     assert my_check is None
     assert my_check_path is None
 
-    my_check = catch_check(check_if_paths_exist,
-                           paths=existing_path,
-                           handle_with=Warning,
-                           message='Path problem')
-    assert my_check is None
-    my_check_path = catch_check(check_if_paths_exist,
-                                paths=Path(existing_path),
-                                handle_with=Warning,
-                                message='Path problem')
-    assert my_check_path is None
-
-    non_existing_path = 'W:/Op/No_no'
-    my_check_not = catch_check(check_if_paths_exist, paths=non_existing_path)
-    my_check_not_path = catch_check(check_if_paths_exist,
-                                    paths=Path(non_existing_path))
-    assert isinstance(my_check_not, FileNotFoundError)
-    with pytest.raises(FileNotFoundError):
-        raise my_check_not
-    assert isinstance(my_check_not_path, FileNotFoundError)
-    with pytest.raises(FileNotFoundError):
-        raise my_check_not_path
-
-    my_check_not = catch_check(check_if_paths_exist,
-                               paths=non_existing_path,
-                               handle_with=Warning,
-                               message='Path problem')
-    assert isinstance(my_check_not, Warning)
-
-
-def test_catch_check_paths_many_paths():
-    existing_paths = os.listdir('.')
-    my_check = catch_check(check_if_paths_exist, paths=existing_paths)
-    my_check_path = catch_check(check_if_paths_exist,
-                                paths=[Path(path) for path in existing_paths])
-    assert my_check is None
-    assert my_check_path is None
-
-    my_check = catch_check(check_if_paths_exist,
-                           paths=existing_paths,
-                           handle_with=Warning,
-                           message='Path issue')
-    assert my_check is None
-
-    non_existing_paths = ['W:/Op/No_no'] + os.listdir('.')
-    my_check_not = catch_check(check_if_paths_exist, paths=non_existing_paths)
-    my_check_not_path = catch_check(
+    my_check = catch_check(
         check_if_paths_exist,
-        paths=[Path(path) for path in non_existing_paths]
+        paths=existing_path,
+        handle_with=Warning,
+        message="Path problem",
+    )
+    assert my_check is None
+    my_check_path = catch_check(
+        check_if_paths_exist,
+        paths=Path(existing_path),
+        handle_with=Warning,
+        message="Path problem",
+    )
+    assert my_check_path is None
+
+    non_existing_path = "W:/Op/No_no"
+    my_check_not = catch_check(check_if_paths_exist, paths=non_existing_path)
+    my_check_not_path = catch_check(
+        check_if_paths_exist, paths=Path(non_existing_path)
     )
     assert isinstance(my_check_not, FileNotFoundError)
     with pytest.raises(FileNotFoundError):
@@ -440,21 +429,61 @@ def test_catch_check_paths_many_paths():
     with pytest.raises(FileNotFoundError):
         raise my_check_not_path
 
-    my_check_not = catch_check(check_if_paths_exist,
-                               paths=non_existing_paths,
-                               handle_with=Warning,
-                               message='Path issue')
+    my_check_not = catch_check(
+        check_if_paths_exist,
+        paths=non_existing_path,
+        handle_with=Warning,
+        message="Path problem",
+    )
+    assert isinstance(my_check_not, Warning)
+
+
+def test_catch_check_paths_many_paths():
+    existing_paths = os.listdir(".")
+    my_check = catch_check(check_if_paths_exist, paths=existing_paths)
+    my_check_path = catch_check(
+        check_if_paths_exist, paths=[Path(path) for path in existing_paths]
+    )
+    assert my_check is None
+    assert my_check_path is None
+
+    my_check = catch_check(
+        check_if_paths_exist,
+        paths=existing_paths,
+        handle_with=Warning,
+        message="Path issue",
+    )
+    assert my_check is None
+
+    non_existing_paths = ["W:/Op/No_no"] + os.listdir(".")
+    my_check_not = catch_check(check_if_paths_exist, paths=non_existing_paths)
+    my_check_not_path = catch_check(
+        check_if_paths_exist, paths=[Path(path) for path in non_existing_paths]
+    )
+    assert isinstance(my_check_not, FileNotFoundError)
+    with pytest.raises(FileNotFoundError):
+        raise my_check_not
+    assert isinstance(my_check_not_path, FileNotFoundError)
+    with pytest.raises(FileNotFoundError):
+        raise my_check_not_path
+
+    my_check_not = catch_check(
+        check_if_paths_exist,
+        paths=non_existing_paths,
+        handle_with=Warning,
+        message="Path issue",
+    )
     assert isinstance(my_check_not, Warning)
 
 
 def test_check_comparison_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
+    with pytest.raises(TypeError, match="required positional argument"):
         check_comparison(1, 1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         check_comparison(item1=1, operator=gt, item_2=2)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         check_comparison(item_1=1, Operator=gt, item_2=2)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         check_comparison(item_1=1, operator=gt, item2=2)
 
 
@@ -471,210 +500,214 @@ def test_check_comparison_positive():
     assert check_comparison(3, ge, 2, Warning) is None
     assert check_comparison(3, gt, 2) is None
     assert check_comparison(3, gt, 2, Warning) is None
-    assert check_comparison('One text', lt, 'one text') is None
-    assert check_comparison('One text', lt, 'one text', Warning) is None
-    assert check_comparison('One text', lt, 'another text') is None
-    assert check_comparison('One text', lt, 'another text', Warning) is None
-    assert check_comparison('abc', is_, 'abc') is None
-    assert check_comparison('abc', is_, 'abc', Warning) is None
-    assert check_comparison('abc', is_not, 'xyz') is None
-    assert check_comparison('abc', is_not, 'xyz', Warning) is None
+    assert check_comparison("One text", lt, "one text") is None
+    assert check_comparison("One text", lt, "one text", Warning) is None
+    assert check_comparison("One text", lt, "another text") is None
+    assert check_comparison("One text", lt, "another text", Warning) is None
+    assert check_comparison("abc", is_, "abc") is None
+    assert check_comparison("abc", is_, "abc", Warning) is None
+    assert check_comparison("abc", is_not, "xyz") is None
+    assert check_comparison("abc", is_not, "xyz", Warning) is None
 
 
 def test_check_comparison_negative():
     with pytest.raises(ValueError):
         check_comparison(3, eq, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(3, eq, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(3, eq, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
         check_comparison(2, ne, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(2, ne, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(2, ne, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
         check_comparison(2, lt, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(2, lt, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(2, lt, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
         check_comparison(2, gt, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(2, gt, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(2, gt, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
         check_comparison(3, lt, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(3, lt, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(3, lt, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
         check_comparison(3, le, 2)
     with warnings.catch_warnings(record=True) as w:
-        check_comparison(3, le, 2, Warning, 'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(3, le, 2, Warning, "This is a testing warning")
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
-        check_comparison('one text', lt, 'another text')
+        check_comparison("one text", lt, "another text")
     with warnings.catch_warnings(record=True) as w:
-        check_comparison('one text', lt, 'another text',
-                         Warning,
-                         'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(
+            "one text",
+            lt,
+            "another text",
+            Warning,
+            "This is a testing warning",
+        )
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
-        check_comparison('abc', is_, 'xyz')
+        check_comparison("abc", is_, "xyz")
     with warnings.catch_warnings(record=True) as w:
-        check_comparison('abc', is_, 'xyz',
-                         Warning,
-                         'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(
+            "abc", is_, "xyz", Warning, "This is a testing warning"
+        )
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ValueError):
-        check_comparison('abc', is_not, 'abc')
+        check_comparison("abc", is_not, "abc")
     with warnings.catch_warnings(record=True) as w:
-        check_comparison('abc', is_not, 'abc',
-                         Warning,
-                         'This is a testing warning')
-        assert 'This is a testing warning' in str(w[-1].message)
+        check_comparison(
+            "abc", is_not, "abc", Warning, "This is a testing warning"
+        )
+        assert "This is a testing warning" in str(w[-1].message)
 
     with pytest.raises(ComparisonError):
-        check_comparison('one text', lt, 'another text',
-                         handle_with=ComparisonError)
+        check_comparison(
+            "one text", lt, "another text", handle_with=ComparisonError
+        )
 
 
 def test_check_all_ifs_edge_cases():
-    with pytest.raises(ValueError, match='at least one condition'):
+    with pytest.raises(ValueError, match="at least one condition"):
         check_all_ifs()
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs(1)
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs(True)
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs(1, 1)
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs(1 > 1, 2 > 1)
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs((20 > 10))
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs(check_if(20 > 10)),
-    with pytest.raises(TypeError, match='Provide all function calls as'):
+    with pytest.raises(TypeError, match="Provide all function calls as"):
         check_all_ifs((check_if, 20 > 10), (check_if(20 > 10)))
 
 
 def test_check_all_ifs():
-    multiple_check_1 = check_all_ifs(
-        (check_if, 2 > 1),
-        (check_if, 'a' == 'a')
-    )
+    multiple_check_1 = check_all_ifs((check_if, 2 > 1), (check_if, "a" == "a"))
     assert all(multiple_check_1.values())
 
     multiple_check_2 = check_all_ifs(
-        (check_if, 2 > 1),
-        (check_if_not, 'a' == 'a')
+        (check_if, 2 > 1), (check_if_not, "a" == "a")
     )
-    assert any(type(value) == AssertionError
-               for value in multiple_check_2.values())
+    assert any(
+        type(value) == AssertionError for value in multiple_check_2.values()
+    )
 
     multiple_check_3 = check_all_ifs(
-        (check_if, 2 > 1),
-        (check_if_not, 'a' == 'a', ValueError)
+        (check_if, 2 > 1), (check_if_not, "a" == "a", ValueError)
     )
-    assert any(type(value) == ValueError
-               for value in multiple_check_3.values())
+    assert any(
+        type(value) == ValueError for value in multiple_check_3.values()
+    )
 
 
 def test_check_all_ifs_warnings():
     multiple_check_1 = check_all_ifs(
-        (check_if, 2 > 1, Warning),
-        (check_if, 'a' == 'a', Warning)
+        (check_if, 2 > 1, Warning), (check_if, "a" == "a", Warning)
     )
     assert all(multiple_check_1.values())
 
     multiple_check_2 = check_all_ifs(
-        (check_if, 2 > 1, Warning),
-        (check_if_not, 'a' == 'a', Warning)
+        (check_if, 2 > 1, Warning), (check_if_not, "a" == "a", Warning)
     )
-    assert any(isinstance(value, Warning)
-               for value in multiple_check_2.values())
+    assert any(
+        isinstance(value, Warning) for value in multiple_check_2.values()
+    )
 
 
 def test_check_if_paths_exist_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
+    with pytest.raises(TypeError, match="required positional argument"):
         check_if_paths_exist()
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        check_if_paths_exist(path='tomato soup is good')
-    with pytest.raises(TypeError, match='Argument paths must be string'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        check_if_paths_exist(path="tomato soup is good")
+    with pytest.raises(TypeError, match="Argument paths must be string"):
         check_if_paths_exist(20)
-    with pytest.raises(TypeError, match='Argument paths must be string'):
+    with pytest.raises(TypeError, match="Argument paths must be string"):
         check_if_paths_exist(True)
-    with pytest.raises(TypeError, match='Argument paths must be string'):
-        check_if_paths_exist(['/some/path', 1, 2])
-    with pytest.raises(TypeError, match='Argument paths must be string'):
-        check_if_paths_exist(['/some/path', Path('/some/path'), False])
+    with pytest.raises(TypeError, match="Argument paths must be string"):
+        check_if_paths_exist(["/some/path", 1, 2])
+    with pytest.raises(TypeError, match="Argument paths must be string"):
+        check_if_paths_exist(["/some/path", Path("/some/path"), False])
     with pytest.raises(ValueError):
-        check_if_paths_exist(os.listdir('.')[0], execution_mode='buuu')
+        check_if_paths_exist(os.listdir(".")[0], execution_mode="buuu")
 
 
 def test_check_if_paths_exist_positive():
-    single_path_to_check = os.listdir('.')[0]
-    list_of_paths_to_check = os.listdir('.')
+    single_path_to_check = os.listdir(".")[0]
+    list_of_paths_to_check = os.listdir(".")
     assert check_if_paths_exist(single_path_to_check) is None
     assert check_if_paths_exist(single_path_to_check, Warning) is None
-    assert check_if_paths_exist(single_path_to_check,
-                                execution_mode='return')
-    assert check_if_paths_exist(single_path_to_check,
-                                handle_with=Warning,
-                                execution_mode='return')
+    assert check_if_paths_exist(single_path_to_check, execution_mode="return")
+    assert check_if_paths_exist(
+        single_path_to_check, handle_with=Warning, execution_mode="return"
+    )
     assert check_if_paths_exist(Path(single_path_to_check)) is None
 
     assert check_if_paths_exist(list_of_paths_to_check) is None
     assert check_if_paths_exist(list_of_paths_to_check, Warning) is None
-    assert check_if_paths_exist(
-        Path(path) for path in list_of_paths_to_check
-    ) is None
+    assert (
+        check_if_paths_exist(Path(path) for path in list_of_paths_to_check)
+        is None
+    )
 
-    check_result = check_if_paths_exist(list_of_paths_to_check,
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        list_of_paths_to_check, execution_mode="return"
+    )
     assert len(check_result) == 2
     assert check_result[0] is None
     assert check_result[1] == []
 
-    check_result = check_if_paths_exist(list_of_paths_to_check,
-                                        handle_with=Warning,
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        list_of_paths_to_check, handle_with=Warning, execution_mode="return"
+    )
     assert len(check_result) == 2
     assert check_result[0] is None
     assert check_result[1] == []
 
 
 def test_check_if_paths_exist_negative():
-    non_existing_path = 'Z:/Op/Oop'
+    non_existing_path = "Z:/Op/Oop"
     with pytest.raises(ValueError):
-        check_if_paths_exist(non_existing_path, execution_mode='buuu')
+        check_if_paths_exist(non_existing_path, execution_mode="buuu")
     with pytest.raises(FileNotFoundError):
         check_if_paths_exist(non_existing_path)
     with pytest.raises(FileNotFoundError):
         check_if_paths_exist(Path(non_existing_path))
     with pytest.raises(FileNotFoundError):
-        check_if_paths_exist([non_existing_path] + os.listdir('.'))
+        check_if_paths_exist([non_existing_path] + os.listdir("."))
     with pytest.raises(IOError):
         check_if_paths_exist(non_existing_path, handle_with=IOError)
 
-    check_result = check_if_paths_exist(non_existing_path,
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        non_existing_path, execution_mode="return"
+    )
     assert len(check_result) == 2
     assert type(check_result[0]) == FileNotFoundError
     with pytest.raises(FileNotFoundError):
         raise check_result[0]
     assert check_result[1] == [non_existing_path]
 
-    check_result = check_if_paths_exist(os.listdir('.') + [non_existing_path],
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        os.listdir(".") + [non_existing_path], execution_mode="return"
+    )
     assert len(check_result) == 2
     assert type(check_result[0]) == FileNotFoundError
     with pytest.raises(FileNotFoundError):
@@ -683,62 +716,66 @@ def test_check_if_paths_exist_negative():
 
 
 def test_check_if_paths_exist_negative_warnings():
-    non_existing_path = 'Z:/Op/Oop'
+    non_existing_path = "Z:/Op/Oop"
     with warnings.catch_warnings(record=True):
-        check_if_paths_exist(non_existing_path, Warning, 'Path issue')
+        check_if_paths_exist(non_existing_path, Warning, "Path issue")
     with warnings.catch_warnings(record=True):
-        check_if_paths_exist(Path(non_existing_path), Warning, 'Path issue')
+        check_if_paths_exist(Path(non_existing_path), Warning, "Path issue")
     with warnings.catch_warnings(record=True):
-        check_if_paths_exist([non_existing_path] + os.listdir('.'),
-                             Warning,
-                             'Path issue')
+        check_if_paths_exist(
+            [non_existing_path] + os.listdir("."), Warning, "Path issue"
+        )
 
-    check_result = check_if_paths_exist(non_existing_path,
-                                        handle_with=Warning,
-                                        message='Path issue',
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        non_existing_path,
+        handle_with=Warning,
+        message="Path issue",
+        execution_mode="return",
+    )
     assert len(check_result) == 2
     assert type(check_result[0]) == Warning
-    assert 'Path issue' in str(check_result[0])
+    assert "Path issue" in str(check_result[0])
     assert check_result[1] == [non_existing_path]
 
-    check_result = check_if_paths_exist([non_existing_path] + os.listdir('.'),
-                                        handle_with=Warning,
-                                        message='Path issue',
-                                        execution_mode='return')
+    check_result = check_if_paths_exist(
+        [non_existing_path] + os.listdir("."),
+        handle_with=Warning,
+        message="Path issue",
+        execution_mode="return",
+    )
     assert len(check_result) == 2
     assert type(check_result[0]) == Warning
-    assert 'Path issue' in str(check_result[0])
+    assert "Path issue" in str(check_result[0])
     assert check_result[1] == [non_existing_path]
 
 
 def test_raise_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
+    with pytest.raises(TypeError, match="required positional argument"):
         _raise()
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _raise(handle_with=TypeError)
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        _raise(handle_with=TypeError, MEssage='This was an error')
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        _raise(handle_with=TypeError, MEssage="This was an error")
     with pytest.raises(
-            TypeError,
-            match='The error argument must be an exception or a warning'):
+        TypeError, match="The error argument must be an exception or a warning"
+    ):
         _raise(20)
     with pytest.raises(
-            TypeError,
-            match='The error argument must be an exception or a warning'):
-        _raise('TypeError')
+        TypeError, match="The error argument must be an exception or a warning"
+    ):
+        _raise("TypeError")
     with pytest.raises(
-            TypeError,
-            match='The error argument must be an exception or a warning'):
-        _raise(['TypeError'])
+        TypeError, match="The error argument must be an exception or a warning"
+    ):
+        _raise(["TypeError"])
     with pytest.raises(
-            TypeError,
-            match='The error argument must be an exception or a warning'):
+        TypeError, match="The error argument must be an exception or a warning"
+    ):
         _raise(NotImplemented)
-    with pytest.raises(TypeError, match='message must be string'):
+    with pytest.raises(TypeError, match="message must be string"):
         _raise(error=TypeError, message=20)
-    with pytest.raises(TypeError, match='message must be string'):
-        _raise(TypeError, ('This was an error', ''))
+    with pytest.raises(TypeError, match="message must be string"):
+        _raise(TypeError, ("This was an error", ""))
 
 
 def test_raise_exception():
@@ -746,8 +783,8 @@ def test_raise_exception():
         _raise(ValueError)
     with pytest.raises(TypeError):
         _raise(TypeError)
-    with pytest.raises(TypeError, match='Incorrect type'):
-        _raise(TypeError, 'Incorrect type')
+    with pytest.raises(TypeError, match="Incorrect type"):
+        _raise(TypeError, "Incorrect type")
 
 
 def test_raise_warning():
@@ -756,163 +793,180 @@ def test_raise_warning():
     with warnings.catch_warnings(record=True):
         _raise(UserWarning)
     with warnings.catch_warnings(record=True):
-        _raise(Warning, message='Problem with something')
+        _raise(Warning, message="Problem with something")
     with warnings.catch_warnings(record=True):
-        _raise(UserWarning, message='Problem with something')
+        _raise(UserWarning, message="Problem with something")
 
 
 def test_check_argument_edge_cases():
-    with pytest.raises(TypeError, match='required positional argument'):
-        check_argument(Argument='x')
+    with pytest.raises(TypeError, match="required positional argument"):
+        check_argument(Argument="x")
 
-    msg = 'check_argument() requires at least one condition to be checked'
+    msg = "check_argument() requires at least one condition to be checked"
     with pytest.raises(ValueError) as msg_error:
         check_argument(10)
     assert str(msg_error.value) == msg
     with pytest.raises(ValueError) as msg_error:
-        check_argument(10, message='Error!')
+        check_argument(10, message="Error!")
     assert str(msg_error.value) == msg
     with pytest.raises(ValueError) as msg_error:
-        check_argument('x', 10, handle_with=TypeError)
+        check_argument("x", 10, handle_with=TypeError)
     assert str(msg_error.value) == msg
 
 
 def test_check_argument_type():
     def foo(x):
-        check_argument(x, 'x', expected_type=str)
+        check_argument(x, "x", expected_type=str)
         pass
-    assert foo('one') is None
+
+    assert foo("one") is None
     with pytest.raises(ArgumentValueError):
         foo(4)
     with pytest.raises(ArgumentValueError):
-        foo(('one', 'two'))
+        foo(("one", "two"))
 
-    assert check_argument(50, 'my_arg', expected_type=int) is None
+    assert check_argument(50, "my_arg", expected_type=int) is None
     assert check_argument(50, expected_type=int) is None
-    assert check_argument('my_arg', 'one', expected_type=str) is None
-    assert check_argument('my_arg', expected_type=str) is None
+    assert check_argument("my_arg", "one", expected_type=str) is None
+    assert check_argument("my_arg", expected_type=str) is None
 
-    with pytest.raises(ArgumentValueError, match='my_arg'):
-        check_argument(50, 'my_arg', expected_type=str)
-    with pytest.raises(ArgumentValueError, match='my_arg'):
-        check_argument('one', 'my_arg', expected_type=int)
-    with pytest.raises(ArgumentValueError, match='argument'):
+    with pytest.raises(ArgumentValueError, match="my_arg"):
+        check_argument(50, "my_arg", expected_type=str)
+    with pytest.raises(ArgumentValueError, match="my_arg"):
+        check_argument("one", "my_arg", expected_type=int)
+    with pytest.raises(ArgumentValueError, match="argument"):
         check_argument(50, expected_type=str)
-    with pytest.raises(ArgumentValueError, match='argument'):
-        check_argument('one', expected_type=int)
+    with pytest.raises(ArgumentValueError, match="argument"):
+        check_argument("one", expected_type=int)
 
 
 def test_check_argument_type_warning():
     def foo(x):
-        check_argument(x, 'x',
-                       expected_type=str,
-                       handle_with=Warning,
-                       message='Incorrect argument?')
+        check_argument(
+            x,
+            "x",
+            expected_type=str,
+            handle_with=Warning,
+            message="Incorrect argument?",
+        )
         pass
-    assert foo('one') is None
+
+    assert foo("one") is None
     with warnings.catch_warnings(record=True) as w:
         foo(4)
-        assert 'Incorrect argument' in str(w[-1].message)
+        assert "Incorrect argument" in str(w[-1].message)
 
-    assert check_argument(50, 'my_arg',
-                          expected_type=int,
-                          handle_with=Warning) is None
-    assert check_argument(50,
-                          expected_type=int,
-                          handle_with=Warning) is None
-
-    with warnings.catch_warnings(record=True) as w:
-        check_argument(50, 'my_arg',
-                       expected_type=str,
-                       handle_with=Warning)
-        assert 'my_arg' in str(w[-1].message)
-        assert 'Incorrect type' in str(w[-1].message)
+    assert (
+        check_argument(50, "my_arg", expected_type=int, handle_with=Warning)
+        is None
+    )
+    assert check_argument(50, expected_type=int, handle_with=Warning) is None
 
     with warnings.catch_warnings(record=True) as w:
-        check_argument('one', 'my_arg',
-                       expected_type=int,
-                       handle_with=Warning)
-        assert 'my_arg' in str(w[-1].message)
-        assert 'Incorrect type' in str(w[-1].message)
+        check_argument(50, "my_arg", expected_type=str, handle_with=Warning)
+        assert "my_arg" in str(w[-1].message)
+        assert "Incorrect type" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_argument(50,
-                       expected_type=str,
-                       handle_with=Warning)
-        assert 'Incorrect type of argument' in str(w[-1].message)
+        check_argument("one", "my_arg", expected_type=int, handle_with=Warning)
+        assert "my_arg" in str(w[-1].message)
+        assert "Incorrect type" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
-        check_argument('one',
-                       expected_type=int,
-                       handle_with=Warning)
-        assert 'Incorrect type of argument' in str(w[-1].message)
+        check_argument(50, expected_type=str, handle_with=Warning)
+        assert "Incorrect type of argument" in str(w[-1].message)
+
+    with warnings.catch_warnings(record=True) as w:
+        check_argument("one", expected_type=int, handle_with=Warning)
+        assert "Incorrect type of argument" in str(w[-1].message)
 
 
 def test_check_argument_choices():
-    assert check_argument(5, 'my_arg', expected_choices=range(10),) is None
+    assert (
+        check_argument(
+            5,
+            "my_arg",
+            expected_choices=range(10),
+        )
+        is None
+    )
     assert check_argument(5, expected_choices=range(10)) is None
 
     def foo(x):
-        check_argument(x, expected_choices=('first choice', 'second choice'))
+        check_argument(x, expected_choices=("first choice", "second choice"))
         pass
-    assert foo('first choice') is None
-    assert foo('second choice') is None
-    with pytest.raises(ArgumentValueError, match='not among valid values'):
-        foo('no choice')
+
+    assert foo("first choice") is None
+    assert foo("second choice") is None
+    with pytest.raises(ArgumentValueError, match="not among valid values"):
+        foo("no choice")
 
     def foo(x):
-        check_argument(x, 'x', expected_choices=('one', 'two'))
+        check_argument(x, "x", expected_choices=("one", "two"))
         pass
-    assert foo('one') is None
-    with pytest.raises(ArgumentValueError,
-                       match="x's value, three, is not among valid values"):
-        foo('three')
 
-    def foo(x):
-        check_argument(x, expected_choices=('one', 'two'))
-        pass
-    assert foo('one') is None
+    assert foo("one") is None
     with pytest.raises(
-            ArgumentValueError,
-            match="argument's value, three, is not among valid values"):
-        foo('three')
+        ArgumentValueError, match="x's value, three, is not among valid values"
+    ):
+        foo("three")
+
+    def foo(x):
+        check_argument(x, expected_choices=("one", "two"))
+        pass
+
+    assert foo("one") is None
+    with pytest.raises(
+        ArgumentValueError,
+        match="argument's value, three, is not among valid values",
+    ):
+        foo("three")
 
 
 def test_check_argument_choices_warnings():
-    assert check_argument(5,
-                          'my_arg',
-                          expected_choices=range(10),
-                          handle_with=Warning) is None
-    assert check_argument(5,
-                          expected_choices=range(10),
-                          handle_with=Warning) is None
+    assert (
+        check_argument(
+            5, "my_arg", expected_choices=range(10), handle_with=Warning
+        )
+        is None
+    )
+    assert (
+        check_argument(5, expected_choices=range(10), handle_with=Warning)
+        is None
+    )
 
     def foo(x):
-        check_argument(x,
-                       expected_choices=('first choice', 'second choice'),
-                       handle_with=Warning)
+        check_argument(
+            x,
+            expected_choices=("first choice", "second choice"),
+            handle_with=Warning,
+        )
         pass
-    assert foo('first choice') is None
-    assert foo('second choice') is None
+
+    assert foo("first choice") is None
+    assert foo("second choice") is None
     with warnings.catch_warnings(record=True) as w:
-        foo('no choice')
-        assert 'no choice' in str(w[-1].message)
-        assert 'not among valid values' in str(w[-1].message)
+        foo("no choice")
+        assert "no choice" in str(w[-1].message)
+        assert "not among valid values" in str(w[-1].message)
 
 
 def test_check_argument_length():
-    assert check_argument(5, 'my_arg',
-                          expected_length=1,
-                          assign_length_to_others=True) is None
-    assert check_argument(5,
-                          expected_length=1,
-                          assign_length_to_others=True) is None
+    assert (
+        check_argument(
+            5, "my_arg", expected_length=1, assign_length_to_others=True
+        )
+        is None
+    )
+    assert (
+        check_argument(5, expected_length=1, assign_length_to_others=True)
+        is None
+    )
 
     def foo(x):
-        check_argument(x, 'x',
-                       expected_length=3,
-                       assign_length_to_others=True)
+        check_argument(x, "x", expected_length=3, assign_length_to_others=True)
         pass
+
     assert foo([1, 2, 3]) is None
     with pytest.raises(ArgumentValueError):
         foo(1)
@@ -920,143 +974,184 @@ def test_check_argument_length():
     def foo(x):
         check_argument(x, expected_length=3, assign_length_to_others=True)
         pass
+
     assert foo([1, 2, 3]) is None
     with pytest.raises(ArgumentValueError):
         foo(1)
 
     def foo(big_x):
-        check_argument(big_x, 'big_x',
-                       expected_length=3,
-                       assign_length_to_others=True)
+        check_argument(
+            big_x, "big_x", expected_length=3, assign_length_to_others=True
+        )
         pass
+
     assert foo([1, 2, 3]) is None
-    with pytest.raises(ArgumentValueError, match='big_x'):
+    with pytest.raises(ArgumentValueError, match="big_x"):
         foo(1)
 
     def foo(big_x):
         check_argument(big_x, expected_length=3, assign_length_to_others=True)
         pass
+
     assert foo([1, 2, 3]) is None
-    with pytest.raises(ArgumentValueError, match='argument'):
+    with pytest.raises(ArgumentValueError, match="argument"):
         foo(1)
 
 
 def test_check_argument_length_warnings():
-    assert check_argument(5, 'my_arg',
-                          expected_length=1,
-                          assign_length_to_others=True,
-                          handle_with=Warning) is None
-    assert check_argument(5,
-                          expected_length=1,
-                          assign_length_to_others=True,
-                          handle_with=Warning) is None
+    assert (
+        check_argument(
+            5,
+            "my_arg",
+            expected_length=1,
+            assign_length_to_others=True,
+            handle_with=Warning,
+        )
+        is None
+    )
+    assert (
+        check_argument(
+            5,
+            expected_length=1,
+            assign_length_to_others=True,
+            handle_with=Warning,
+        )
+        is None
+    )
 
     def foo(x):
-        check_argument(x, 'x',
-                       expected_length=3,
-                       assign_length_to_others=True,
-                       handle_with=Warning)
+        check_argument(
+            x,
+            "x",
+            expected_length=3,
+            assign_length_to_others=True,
+            handle_with=Warning,
+        )
         pass
+
     assert foo([1, 2, 3]) is None
     with warnings.catch_warnings(record=True) as w:
         foo(1)
-        assert 'length' in str(w[-1].message)
+        assert "length" in str(w[-1].message)
 
     def foo(x):
-        check_argument(x,
-                       expected_length=3,
-                       assign_length_to_others=True,
-                       handle_with=Warning)
+        check_argument(
+            x,
+            expected_length=3,
+            assign_length_to_others=True,
+            handle_with=Warning,
+        )
         pass
+
     assert foo([1, 2, 3]) is None
     with warnings.catch_warnings(record=True) as w:
         foo(1)
-        assert 'length' in str(w[-1].message)
+        assert "length" in str(w[-1].message)
 
 
 def test_check_argument_mix():
     def foo(x):
-        check_argument(x, 'x', expected_type=int, condition=x % 2 == 0)
+        check_argument(x, "x", expected_type=int, condition=x % 2 == 0)
         pass
+
     with pytest.raises(TypeError):
-        x = 'one'
-        check_argument(argument=x,
-                       argument_name='x',
-                       expected_type=int,
-                       condition=x % 2 == 0)
+        x = "one"
+        check_argument(
+            argument=x,
+            argument_name="x",
+            expected_type=int,
+            condition=x % 2 == 0,
+        )
     with pytest.raises(TypeError):
-        foo('one')
+        foo("one")
 
 
 def test_check_argument_mix_warnings():
     def foo(x):
-        check_argument(x, 'x',
-                       expected_type=int,
-                       expected_length=3,
-                       handle_with=Warning)
+        check_argument(
+            x, "x", expected_type=int, expected_length=3, handle_with=Warning
+        )
         pass
+
     with warnings.catch_warnings(record=True) as w:
-        foo('one')
-        assert 'type' in str(w[-1].message)
+        foo("one")
+        assert "type" in str(w[-1].message)
 
 
 def test_check_easycheck_arguments_edge_cases():
-    with pytest.raises(ValueError, match='Provide at least one argument'):
+    with pytest.raises(ValueError, match="Provide at least one argument"):
         _check_easycheck_arguments()
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Handle_with=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Message=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Condition=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Operator=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Assign_length_to_others=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Execution_mode=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Expected_type=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(Expected_length=1)
-    with pytest.raises(TypeError, match='unexpected keyword'):
+    with pytest.raises(TypeError, match="unexpected keyword"):
         _check_easycheck_arguments(handle_with=ValueError, Message=1)
 
-    with pytest.raises(TypeError, match='handle_with must be an exception'):
+    with pytest.raises(TypeError, match="handle_with must be an exception"):
         _check_easycheck_arguments(handle_with=20)
 
-    with pytest.raises(TypeError, match='handle_with must be an exception'):
+    with pytest.raises(TypeError, match="handle_with must be an exception"):
         _check_easycheck_arguments(handle_with=NotImplemented)
 
 
 def test_check_easycheck_arguments():
     assert _check_easycheck_arguments(handle_with=LengthError) is None
     with pytest.raises(TypeError):
-        _check_easycheck_arguments(handle_with='NonExistingError')
+        _check_easycheck_arguments(handle_with="NonExistingError")
 
-    with pytest.raises(TypeError, match='must be an exception'):
+    with pytest.raises(TypeError, match="must be an exception"):
         _check_easycheck_arguments(handle_with=sum)
 
     with pytest.raises(TypeError):
         _check_easycheck_arguments(handle_with=LengthError, message=False)
-    assert _check_easycheck_arguments(handle_with=LengthError,
-                                      message='This is error') is None
+    assert (
+        _check_easycheck_arguments(
+            handle_with=LengthError, message="This is error"
+        )
+        is None
+    )
     with pytest.raises(TypeError):
         _check_easycheck_arguments(handle_with=LengthError, message=25)
 
-    assert _check_easycheck_arguments(handle_with=ValueError,
-                                      condition='a' == 'a') is None
-    assert _check_easycheck_arguments(condition='a' == 'a') is None
-    assert _check_easycheck_arguments(handle_with=ValueError, condition=2 > 1) is None
-    assert _check_easycheck_arguments(handle_with=ValueError, condition=2 < 1) is None
-    assert _check_easycheck_arguments(handle_with=ValueError,
-                                      condition=2 == '2') is None
-    assert _check_easycheck_arguments(condition=2 == '2') is None
+    assert (
+        _check_easycheck_arguments(
+            handle_with=ValueError, condition="a" == "a"
+        )
+        is None
+    )
+    assert _check_easycheck_arguments(condition="a" == "a") is None
+    assert (
+        _check_easycheck_arguments(handle_with=ValueError, condition=2 > 1)
+        is None
+    )
+    assert (
+        _check_easycheck_arguments(handle_with=ValueError, condition=2 < 1)
+        is None
+    )
+    assert (
+        _check_easycheck_arguments(handle_with=ValueError, condition=2 == "2")
+        is None
+    )
+    assert _check_easycheck_arguments(condition=2 == "2") is None
     with pytest.raises(ValueError):
-        _check_easycheck_arguments(handle_with=ValueError,
-                                   condition='not a comparison')
+        _check_easycheck_arguments(
+            handle_with=ValueError, condition="not a comparison"
+        )
     with pytest.raises(ValueError):
-        _check_easycheck_arguments(condition='not a comparison')
+        _check_easycheck_arguments(condition="not a comparison")
 
     for this_operator in get_possible_operators():
         assert _check_easycheck_arguments(operator=this_operator) is None
@@ -1065,29 +1160,30 @@ def test_check_easycheck_arguments():
 
     assert _check_easycheck_arguments(assign_length_to_others=True) is None
     assert _check_easycheck_arguments(assign_length_to_others=False) is None
-    for this_assignment in ('nothing', 22, [1]):
+    for this_assignment in ("nothing", 22, [1]):
         with pytest.raises(TypeError):
             _check_easycheck_arguments(assign_length_to_others=this_assignment)
 
-    assert _check_easycheck_arguments(execution_mode='return') is None
-    assert _check_easycheck_arguments(execution_mode='raise') is None
-    for this_mode in ('nothing', 22, [1]):
+    assert _check_easycheck_arguments(execution_mode="return") is None
+    assert _check_easycheck_arguments(execution_mode="raise") is None
+    for this_mode in ("nothing", 22, [1]):
         with pytest.raises(ValueError):
             _check_easycheck_arguments(execution_mode=this_mode)
 
     for this_length in (0, 3, 5, 7):
         assert _check_easycheck_arguments(expected_length=this_length) is None
-        assert _check_easycheck_arguments(
-            expected_length=float(this_length)
-        ) is None
+        assert (
+            _check_easycheck_arguments(expected_length=float(this_length))
+            is None
+        )
     assert _check_easycheck_arguments(expected_length=(5)) is None
-    for this_length in ('0', [3], LengthError):
+    for this_length in ("0", [3], LengthError):
         with pytest.raises(TypeError):
             _check_easycheck_arguments(expected_length=this_length)
 
     for this_type in (str, int, float, bool, tuple, list, Generator):
         assert _check_easycheck_arguments(expected_type=this_type) is None
-    for this_type in ('str', 25, True, 1.1):
+    for this_type in ("str", 25, True, 1.1):
         with pytest.raises(TypeError):
             _check_easycheck_arguments(expected_type=this_type)
     assert _check_easycheck_arguments(expected_type=(str, tuple)) is None
@@ -1095,42 +1191,46 @@ def test_check_easycheck_arguments():
     assert _check_easycheck_arguments(expected_type=[str, tuple]) is None
     assert _check_easycheck_arguments(expected_type={str, tuple}) is None
     with pytest.raises(TypeError):
-        _check_easycheck_arguments(expected_type='boolintstrcomplexlist')
+        _check_easycheck_arguments(expected_type="boolintstrcomplexlist")
     with pytest.raises(TypeError):
         _check_easycheck_arguments(expected_type=(str, tuple, list, 26))
 
-    assert _check_easycheck_arguments(
-        expected_type=(str, tuple, list),
-        condition=2 < 2,
-        expected_length=3,
-        execution_mode='raise',
-        assign_length_to_others=True
-    ) is None
+    assert (
+        _check_easycheck_arguments(
+            expected_type=(str, tuple, list),
+            condition=2 < 2,
+            expected_length=3,
+            execution_mode="raise",
+            assign_length_to_others=True,
+        )
+        is None
+    )
 
     with pytest.raises(TypeError):
         _check_easycheck_arguments(
             expected_type=(str, tuple, list),
             condition=2 < 2,
             expected_length=3,
-            execution_mode='raise',
-            assign_length_to_others='yes'
+            execution_mode="raise",
+            assign_length_to_others="yes",
         )
 
 
 def test_make_message_edge_cases():
     with pytest.raises(TypeError, match="required positional argument"):
-        _make_message('Provided')
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        _make_message(message='Provided')
-    with pytest.raises(TypeError, match='unexpected keyword'):
-        _make_message(message_provided='Provided',
-                      Message_otherwise='Otherwise')
+        _make_message("Provided")
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        _make_message(message="Provided")
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        _make_message(
+            message_provided="Provided", Message_otherwise="Otherwise"
+        )
 
 
 def test_make_message():
-    assert _make_message(None, 'Otherwise') == 'Otherwise'
-    assert _make_message('Provided', 'Otherwise') == 'Provided'
-    assert _make_message('Provided', 'Otherwise') == 'Provided'
+    assert _make_message(None, "Otherwise") == "Otherwise"
+    assert _make_message("Provided", "Otherwise") == "Provided"
+    assert _make_message("Provided", "Otherwise") == "Provided"
 
 
 def test_assert_functions():
@@ -1142,24 +1242,29 @@ def test_assert_functions():
     with pytest.raises(AssertionError):
         assert_if_not(10 > 5) and check_if_not(10 > 5) is None
 
-    assert assert_instance((10, 10), tuple) == check_instance((10, 10), tuple)
+    assert assert_type((10, 10), tuple) == check_type((10, 10), tuple)
     with pytest.raises(TypeError):
-        assert_instance(10, tuple) and check_instance(10, tuple) is None
+        assert_type(10, tuple) and check_type(10, tuple) is None
 
-    assert assert_length('str', 3) == check_length('str', 3)
-    assert (
-        assert_length(5, 1, assign_length_to_others=True) ==
-        check_length(5, 1, assign_length_to_others=True))
+    assert assert_length("str", 3) == check_length("str", 3)
+    assert assert_length(5, 1, assign_length_to_others=True) == check_length(
+        5, 1, assign_length_to_others=True
+    )
     with pytest.raises(TypeError):
         assert_length(5, 3) and check_length(5, 3) is None
     with pytest.raises(LengthError):
-        (assert_length(5, 3, assign_length_to_others=True)
-         and check_length(5, 3, assign_length_to_others=True) is None)
+        (
+            assert_length(5, 3, assign_length_to_others=True)
+            and check_length(5, 3, assign_length_to_others=True) is None
+        )
 
-    existing_file = os.listdir('.')[0]
-    assert (check_if_paths_exist(existing_file, execution_mode='return') ==
-            assert_paths(existing_file, execution_mode='return'))
-    assert (check_if_paths_exist('Q:/E/', execution_mode='return')[1] ==
-            assert_paths('Q:/E/', execution_mode='return')[1])
+    existing_file = os.listdir(".")[0]
+    assert check_if_paths_exist(
+        existing_file, execution_mode="return"
+    ) == assert_paths(existing_file, execution_mode="return")
+    assert (
+        check_if_paths_exist("Q:/E/", execution_mode="return")[1]
+        == assert_paths("Q:/E/", execution_mode="return")[1]
+    )
     with pytest.raises(FileNotFoundError):
-        assert_paths('Q:/E/') and check_if_paths_exist('Q:/E/') is None
+        assert_paths("Q:/E/") and check_if_paths_exist("Q:/E/") is None


### PR DESCRIPTION
This merge request comes with the following changes:
* `check_instance()` is now `check_type()` and `assert_instance()` is now `assert_type()`
* `check_instance()` and `assert_instance()` are kept (as aliases) for backward compatibility 
* documentation and tests have been updated
* version increased to 0.3.3
* `black` was added to `extras_require` (so, for development purposes)
* versions were removed from `pytest` and `wheel` so that the newest versions are installed with a new venv