### PR TITLE
29 add function annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="easycheck",
-    version="0.9.2",
+    version="0.10.0",
     author="Nyggus, Ke Boan & Darsoo",
     author_email="nyggus@gmail.com",
     license="MIT",

--- a/tests/test_easycheck.py
+++ b/tests/test_easycheck.py
@@ -476,7 +476,7 @@ def test_catch_check_edge_cases():
     with pytest.raises(TypeError, match="easycheck function"):
         catch_check(1)
     with pytest.raises(
-        ArgumentValueError, match="acceptable valid easycheck functions"
+        TypeError, match="does not seem to be a easycheck function"
     ):
         catch_check(sum)
 


### PR DESCRIPTION
Closes [#29 Add function annotations](https://github.com/nyggus/easycheck/issues/29)

In four locations `# type: ignore` is added to satisfy `mypy`. These can be worked on in a future task - [#55 Analyze type ignores](https://github.com/nyggus/easycheck/issues/55).